### PR TITLE
Add GCEImageService.

### DIFF
--- a/cloudbridge/__init__.py
+++ b/cloudbridge/__init__.py
@@ -19,3 +19,6 @@ def init_logging():
     """
     logging.basicConfig(stream=sys.stdout)
     logging.getLogger(__name__).setLevel(logging.DEBUG)
+
+log = logging.getLogger('cloudbridge')
+log.addHandler(logging.StreamHandler())

--- a/cloudbridge/cloud/providers/gce/resources.py
+++ b/cloudbridge/cloud/providers/gce/resources.py
@@ -7,6 +7,7 @@ from cloudbridge.cloud.base.resources import BaseMachineImage
 from cloudbridge.cloud.base.resources import BasePlacementZone
 from cloudbridge.cloud.base.resources import BaseRegion
 from cloudbridge.cloud.interfaces.resources import MachineImageState
+import cloudbridge as cb
 
 import googleapiclient
 import re
@@ -235,7 +236,7 @@ class GCEMachineImage(BaseMachineImage):
         if match:
             project = match.group(1)
         else:
-            print("Project name is not found.")
+            cb.log.warning("Project name is not found.")
             return
         try:
             response = self._provider.gce_compute \
@@ -248,5 +249,6 @@ class GCEMachineImage(BaseMachineImage):
                 self._gce_image = response
         except googleapiclient.errors.HttpError as http_error:
             # image no longer exists
-            print("googleapiclient.errors.HttpError: {0}".format(http_error))
+            cb.log.warning(
+                "googleapiclient.errors.HttpError: {0}".format(http_error))
             self._gce_image['status'] = "unknown"

--- a/cloudbridge/cloud/providers/gce/resources.py
+++ b/cloudbridge/cloud/providers/gce/resources.py
@@ -9,7 +9,7 @@ from cloudbridge.cloud.base.resources import BaseRegion
 from cloudbridge.cloud.interfaces.resources import MachineImageState
 
 import googleapiclient
-
+import re
 
 class GCEKeyPair(BaseKeyPair):
 
@@ -229,10 +229,18 @@ class GCEMachineImage(BaseMachineImage):
         Refreshes the state of this instance by re-querying the cloud provider
         for its latest state.
         """
+        resource_link = self._gce_image['selfLink']
+        project_pattern = 'projects/(.*?)/'
+        match = re.search(project_pattern, resource_link)
+        if match:
+            project = match.group(1)
+        else:
+            print("Project name is not found.")
+            return
         try:
             response = self._provider.gce_compute \
                                   .images() \
-                                  .get(project=self._provider.project_name,
+                                  .get(project=project,
                                        image=self.name) \
                                   .execute()
             if response:

--- a/cloudbridge/cloud/providers/gce/resources.py
+++ b/cloudbridge/cloud/providers/gce/resources.py
@@ -210,7 +210,7 @@ class GCEMachineImage(BaseMachineImage):
         :rtype: ``str``
         :return: Description for this image as returned by the cloud middleware
         """
-        return self._gce_image['description']
+        return self._gce_image.get('description', '')
 
     def delete(self):
         """

--- a/cloudbridge/cloud/providers/gce/resources.py
+++ b/cloudbridge/cloud/providers/gce/resources.py
@@ -192,7 +192,7 @@ class GCEMachineImage(BaseMachineImage):
         :rtype: ``str``
         :return: ID for this instance as returned by the cloud middleware.
         """
-        return self._gce_image['id']
+        return self._gce_image['name']
 
     @property
     def name(self):

--- a/cloudbridge/cloud/providers/gce/services.py
+++ b/cloudbridge/cloud/providers/gce/services.py
@@ -7,6 +7,8 @@ from cloudbridge.cloud.base.services import BaseRegionService
 from cloudbridge.cloud.base.services import BaseSecurityGroupService
 from cloudbridge.cloud.base.services import BaseSecurityService
 from cloudbridge.cloud.providers.gce import helpers
+import cloudbridge as cb
+
 from collections import namedtuple
 import hashlib
 import googleapiclient
@@ -17,7 +19,6 @@ from .resources import GCEMachineImage
 from .resources import GCEInstanceType
 from .resources import GCEKeyPair
 from .resources import GCERegion
-
 
 class GCESecurityService(BaseSecurityService):
 
@@ -289,7 +290,7 @@ class GCEImageService(BaseImageService):
                                         .list(project=project) \
                                         .execute()
             except googleapiclient.errors.HttpError as http_error:
-                print("googleapiclient.errors.HttpError: {0}".format(
+                cb.log.warning("googleapiclient.errors.HttpError: {0}".format(
                     http_error))
             if 'items' in response:
                 self._public_images.extend(
@@ -312,14 +313,15 @@ class GCEImageService(BaseImageService):
         except TypeError as type_error:
             # The API will throw an TypeError, if parameter `image` does not
             # match the pattern "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?".
-            print("TypeError: {0}".format(type_error))
+            cb.log.warning("TypeError: {0}".format(type_error))
         except googleapiclient.errors.HttpError as http_error:
             # If the image is not found in project-specific private images,
             # look for this image in public images.
             for public_image in self._public_images:
                 if public_image.name == image_name:
                     return public_image
-            print("googleapiclient.errors.HttpError: {0}".format(http_error))
+            cb.log.warning(
+                "googleapiclient.errors.HttpError: {0}".format(http_error))
         return None
 
     def find(self, name, limit=None, marker=None):
@@ -341,7 +343,7 @@ class GCEImageService(BaseImageService):
                     images = [GCEMachineImage(self.provider, image) for image
                               in response['items']]
             except googleapiclient.errors.HttpError as http_error:
-                print(
+                cb.log.warning(
                     "googleapiclient.errors.HttpError: {0}".format(http_error))
         images.extend(self._public_images)
         images = [image for image in images if image.name == filters['name']]
@@ -366,7 +368,7 @@ class GCEImageService(BaseImageService):
                     images = [GCEMachineImage(self.provider, image) for image
                               in response['items']]
             except googleapiclient.errors.HttpError as http_error:
-                print(
+                cb.log.warning(
                     "googleapiclient.errors.HttpError: {0}".format(http_error))
         images.extend(self._public_images)
         return ClientPagedResultList(self.provider, images,

--- a/cloudbridge/cloud/providers/gce/services.py
+++ b/cloudbridge/cloud/providers/gce/services.py
@@ -275,12 +275,14 @@ class GCEImageService(BaseImageService):
         super(GCEImageService, self).__init__(provider)
         self._public_images = None
 
-    PUBLIC_IMAGE_PROJECTS = ['centos-cloud', 'coreos-cloud', 'debian-cloud',
+    _PUBLIC_IMAGE_PROJECTS = ['centos-cloud', 'coreos-cloud', 'debian-cloud',
                              'opensuse-cloud', 'ubuntu-os-cloud']
 
     def _retrieve_public_images(self):
+        if self._public_images is not None:
+            return
         self._public_images = []
-        for project in GCEImageService.PUBLIC_IMAGE_PROJECTS:
+        for project in GCEImageService._PUBLIC_IMAGE_PROJECTS:
             try:
                 response = self.provider.gce_compute \
                                         .images() \
@@ -298,8 +300,7 @@ class GCEImageService(BaseImageService):
         """
         Returns an Image given its name
         """
-        if self._public_images == None:
-            self._retrieve_public_images()
+        self._retrieve_public_images()
         try:
             image = self.provider.gce_compute \
                                   .images() \
@@ -313,30 +314,35 @@ class GCEImageService(BaseImageService):
             # match the pattern "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?".
             print("TypeError: {0}".format(type_error))
         except googleapiclient.errors.HttpError as http_error:
+            # If the image is not found in project-specific private images,
+            # look for this image in public images.
+            for public_image in self._public_images:
+                if public_image.name == image_name:
+                    return public_image
             print("googleapiclient.errors.HttpError: {0}".format(http_error))
-        for public_image in self._public_images:
-            if public_image.name == image_name:
-                return public_image
         return None
 
     def find(self, name, limit=None, marker=None):
         """
         Searches for an image by a given list of attributes
         """
-        if self._public_images == None:
-            self._retrieve_public_images()
+        self._retrieve_public_images()
         filters = {'name': name}
         images = []
-        try:
-            response = self.provider.gce_compute \
-                                    .images() \
-                                  .list(project=self.provider.project_name) \
-                                  .execute()
-            if 'items' in response:
-                images = [GCEMachineImage(self.provider, image) for image
-                          in response['items']]
-        except googleapiclient.errors.HttpError as http_error:
-            print("googleapiclient.errors.HttpError: {0}".format(http_error))
+        if (self.provider.project_name not in
+            GCEImageService._PUBLIC_IMAGE_PROJECTS):
+            try:
+                response = self.provider \
+                               .gce_compute \
+                               .images() \
+                               .list(project=self.provider.project_name) \
+                               .execute()
+                if 'items' in response:
+                    images = [GCEMachineImage(self.provider, image) for image
+                              in response['items']]
+            except googleapiclient.errors.HttpError as http_error:
+                print(
+                    "googleapiclient.errors.HttpError: {0}".format(http_error))
         images.extend(self._public_images)
         images = [image for image in images if image.name == filters['name']]
         return ClientPagedResultList(self.provider, images,
@@ -346,19 +352,22 @@ class GCEImageService(BaseImageService):
         """
         List all images.
         """
-        if self._public_images == None:
-            self._retrieve_public_images()
+        self._retrieve_public_images()
         images = []
-        try:
-            response = self.provider.gce_compute \
-                                  .images() \
-                                  .list(project=self.provider.project_name) \
-                                  .execute()
-            if 'items' in response:
-                images = [GCEMachineImage(self.provider, image) for image
-                          in response['items']]
-        except googleapiclient.errors.HttpError as http_error:
-            print("googleapiclient.errors.HttpError: {0}".format(http_error))
+        if (self.provider.project_name not in
+            GCEImageService._PUBLIC_IMAGE_PROJECTS):
+            try:
+                response = self.provider \
+                               .gce_compute \
+                               .images() \
+                               .list(project=self.provider.project_name) \
+                               .execute()
+                if 'items' in response:
+                    images = [GCEMachineImage(self.provider, image) for image
+                              in response['items']]
+            except googleapiclient.errors.HttpError as http_error:
+                print(
+                    "googleapiclient.errors.HttpError: {0}".format(http_error))
         images.extend(self._public_images)
         return ClientPagedResultList(self.provider, images,
                                      limit=limit, marker=marker)

--- a/cloudbridge/cloud/providers/gce/services.py
+++ b/cloudbridge/cloud/providers/gce/services.py
@@ -298,15 +298,15 @@ class GCEImageService(BaseImageService):
                     [GCEMachineImage(self.provider, image) for image
                      in response['items']])
 
-    def get(self, image_name):
+    def get(self, image_id):
         """
-        Returns an Image given its name
+        Returns an Image given its id
         """
         try:
             image = self.provider.gce_compute \
                                   .images() \
                                   .get(project=self.provider.project_name,
-                                       image=image_name) \
+                                       image=image_id) \
                                   .execute()
             if image:
                 return GCEMachineImage(self.provider, image)
@@ -319,7 +319,7 @@ class GCEImageService(BaseImageService):
             # look for this image in public images.
             self._retrieve_public_images()
             for public_image in self._public_images:
-                if public_image.name == image_name:
+                if public_image.id == image_id:
                     return public_image
             cb.log.warning(
                 "googleapiclient.errors.HttpError: {0}".format(http_error))
@@ -331,8 +331,7 @@ class GCEImageService(BaseImageService):
         """
         filters = {'name': name}
         # Retrieve all available images by setting limit to sys.maxsize
-        images = self.list(limit=sys.maxsize, marker=marker)
-        images = [image for image in images if image.name == filters['name']]
+        images = [image for image in self if image.name == filters['name']]
         return ClientPagedResultList(self.provider, images,
                                      limit=limit, marker=marker)
 


### PR DESCRIPTION
Hi @nuwang @afgane @chiniforooshan @mbookman

This pull request adds GCEImageService and related classes.

Currently, the change does not pass test_image_service.py, since the test needs to bring up a test instance and GCEInstanceService has yet to be implemented.

I tested the GCEImageService and related attributes manually as follows:

`export GCE_PROJECT_NAME=ubuntu-os-cloud   # Using a public GCE project`

`from cloudbridge.cloud.factory import CloudProviderFactory, ProviderList`
`provider = CloudProviderFactory().create_provider(ProviderList.GCE, {})`
`# List all Ubuntu images`
`print(provider.compute.images.list())`
`# Find Ubuntu images by name`
`print(provider.compute.images.find('ubuntu-1604-xenial-v20160627'))`
`# Find no Ubuntu images matching 'ubuntu-1604-xenial-v20160628'`
`print(provider.compute.images.find('ubuntu-1604-xenial-v20160628'))`
`# Get Ubuntu image by name`
`image = provider.compute.images.get('ubuntu-1604-xenial-v20160627')`
`# List attributes of the image`
`image.id`
`image.name`
`image.description`
`image.state`
`image.refresh()`
`image.name`

I also tested on deleting a private image in a private GCE project.
