### PR TITLE
Merge master into gce and resolve network id issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,15 @@ exploring the API:
   print(provider.security.key_pairs.list())
 
 
+Citation
+~~~~~~~~
+
+N. Goonasekera, A. Lonie, J. Taylor, and E. Afgan,
+"CloudBridge: a Simple Cross-Cloud Python Library,"
+presented at the Proceedings of the XSEDE16 Conference on Diversity, Big Data, and Science at Scale, Miami, USA, 2016.
+DOI: http://dx.doi.org/10.1145/2949550.2949648
+
+
 Documentation
 ~~~~~~~~~~~~~
 Documentation can be found at https://cloudbridge.readthedocs.org.

--- a/cloudbridge/cloud/base/services.py
+++ b/cloudbridge/cloud/base/services.py
@@ -146,6 +146,8 @@ class BaseNetworkService(
         super(BaseNetworkService, self).__init__(provider)
 
     def delete(self, network_id):
+        if network_id is None:
+            return True
         network = self.get(network_id)
         if network:
             network.delete()

--- a/cloudbridge/cloud/interfaces/__init__.py
+++ b/cloudbridge/cloud/interfaces/__init__.py
@@ -5,10 +5,10 @@ from .provider import CloudProvider  # noqa
 from .provider import TestMockHelperMixin  # noqa
 from .resources import CloudServiceType  # noqa
 from .resources import InstanceState  # noqa
-from .resources import InvalidConfigurationException  # noqa
 from .resources import LaunchConfig  # noqa
 from .resources import MachineImageState  # noqa
 from .resources import NetworkState  # noqa
 from .resources import Region  # noqa
 from .resources import SnapshotState  # noqa
 from .resources import VolumeState  # noqa
+from .exceptions import InvalidConfigurationException  # noqa

--- a/cloudbridge/cloud/interfaces/exceptions.py
+++ b/cloudbridge/cloud/interfaces/exceptions.py
@@ -1,0 +1,38 @@
+"""
+Specification for exceptions raised by a provider
+"""
+
+
+class CloudBridgeBaseException(Exception):
+    """
+    Base class for all CloudBridge exceptions
+    """
+    pass
+
+
+class WaitStateException(CloudBridgeBaseException):
+    """
+    Marker interface for object wait exceptions.
+    Thrown when a timeout or errors occurs waiting for an object does not reach
+    the expected state within a specified time limit.
+    """
+    pass
+
+
+class InvalidConfigurationException(CloudBridgeBaseException):
+    """
+    Marker interface for invalid launch configurations.
+    Thrown when a combination of parameters in a LaunchConfig
+    object results in an illegal state.
+    """
+    pass
+
+
+class ProviderConnectionException(CloudBridgeBaseException):
+    """
+    Marker interface for connection errors to a cloud provider.
+    Thrown when cloudbridge is unable to connect with a provider,
+    for example, when credentials are incorrect, or connection
+    settings are invalid.
+    """
+    pass

--- a/cloudbridge/cloud/interfaces/provider.py
+++ b/cloudbridge/cloud/interfaces/provider.py
@@ -55,6 +55,32 @@ class CloudProvider(object):
         """
 
     @abstractmethod
+    def authenticate(self):
+        """
+        Checks whether a provider can be successfully authenticated with the
+        configured settings. Clients are *not* required to call this method
+        prior to accessing provider services, as most cloud connections are
+        initialized lazily. The authenticate() method will return True if
+        cloudbridge can establish a successful connection to the provider.
+        It will raise an exception with the appropriate error details
+        otherwise.
+
+        Example:
+
+        .. code-block:: python
+
+            try:
+                if provider.authenticate():
+                   print("Provider connection successful")
+            except ProviderConnectionException as e:
+                print("Could not authenticate with provider: %s" % (e, ))
+
+        :rtype: :class:`bool`
+        :return: ``True`` if authentication is successful.
+        """
+        pass
+
+    @abstractmethod
     def has_service(self, service_type):
         """
         Checks whether this provider supports a given service.

--- a/cloudbridge/cloud/interfaces/resources.py
+++ b/cloudbridge/cloud/interfaces/resources.py
@@ -52,34 +52,6 @@ class CloudResource(object):
         pass
 
 
-class CloudBridgeBaseException(Exception):
-
-    """
-    Base class for all CloudBridge exceptions
-    """
-    pass
-
-
-class WaitStateException(CloudBridgeBaseException):
-
-    """
-    Marker interface for object wait exceptions.
-    Thrown when a timeout or errors occurs waiting for an object does not reach
-    the expected state within a specified time limit.
-    """
-    pass
-
-
-class InvalidConfigurationException(CloudBridgeBaseException):
-
-    """
-    Marker interface for invalid launch configurations.
-    Thrown when a combination of parameters in a LaunchConfig
-    object results in an illegal state.
-    """
-    pass
-
-
 class Configuration(dict):
     """
     Represents a cloudbridge configuration object
@@ -632,9 +604,11 @@ class MachineImageState(object):
 
 class LaunchConfig(object):
     """
-    Represents an advanced launch configuration object, containing
-    information such as BlockDeviceMappings, NetworkInterface configurations,
-    and other advanced options which may be useful when launching an instance.
+    Represents an advanced launch configuration object.
+
+    Theis object can contain information such as BlockDeviceMappings
+    configurations, and other advanced options which may be useful when
+    launching an instance.
 
     Example:
 
@@ -642,10 +616,9 @@ class LaunchConfig(object):
 
         lc = provider.compute.instances.create_launch_config()
         lc.add_block_device(...)
-        lc.add_network_interface(...)
 
         inst = provider.compute.instances.create(name, image, instance_type,
-                                               launch_config=lc)
+                                                 network, launch_config=lc)
     """
 
     @abstractmethod
@@ -734,34 +707,6 @@ class LaunchConfig(object):
         :type  delete_on_terminate: ``bool``
         :param delete_on_terminate: Determines whether to delete or keep the
                                     volume on instance termination.
-        """
-        pass
-
-    @abstractmethod
-    def add_network_interface(self, net_id):
-        """
-        Add a private network info to the launch configuration.
-
-        Example:
-
-        .. code-block:: python
-
-            lc = provider.compute.instances.create_launch_config()
-
-            # 1. Add a VPC subnet for use with AWS
-            lc.add_network_interface('subnet-c24aeaff')
-
-            # 2. Add a network ID for use with OpenStack
-            lc.add_network_interface('5820c766-75fe-4fc6-96ef-798f67623238')
-
-        :type net_id: ``str``
-        :param net_id: Network ID to launch an instance into. This is a
-                       preliminary implementation (pending full private cloud
-                       support within CloudBridge) so native network IDs need
-                       to be supplied. For OpenStack, this is the Neutron
-                       network ID. For AWS, this is a VPC subnet ID. For the
-                       time being, only a single network interface can be
-                       supplied.
         """
         pass
 
@@ -1841,6 +1786,16 @@ class SecurityGroup(CloudResource):
 
         :rtype: ``str``
         :return: A description of this security group.
+        """
+        pass
+
+    @abstractproperty
+    def network_id(self):
+        """
+        Network ID with which this security group is associated.
+
+        :rtype: ``str``
+        :return: Provider-supplied network ID or ``None`` is not available.
         """
         pass
 

--- a/cloudbridge/cloud/interfaces/services.py
+++ b/cloudbridge/cloud/interfaces/services.py
@@ -200,7 +200,7 @@ class InstanceService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, name, image, instance_type, zone=None,
+    def create(self, name, image, instance_type, network=None, zone=None,
                key_pair=None, security_groups=None, user_data=None,
                launch_config=None,
                **kwargs):
@@ -217,6 +217,20 @@ class InstanceService(PageableObjectMixin, CloudService):
         :type  instance_type: ``InstanceType`` or ``str``
         :param instance_type: The InstanceType or name, specifying the size of
                               the instance to boot into
+
+        :type  network:  ``Network`` or ``str``
+        :param network:  The Network or an ID with which the instance should
+                         be associated. If no network was specified, this
+                         method will attempt to find a 'default' one and launch
+                         the instance using that network. A 'default' network
+                         is one tagged as such by the native API. If such tag
+                         or functionality does not exist, an attempt to create
+                         a new network (by default called 'CloudBridgeNet')
+                         will be made. If that falls through, an attempt will
+                         be made to launch the instance without specifying the
+                         network parameter (this is under the assumption the
+                         private networking functionality is not available on
+                         the provider).
 
         :type  zone: ``Zone`` or ``str``
         :param zone: The Zone or its name, where the instance should be placed.
@@ -238,7 +252,7 @@ class InstanceService(PageableObjectMixin, CloudService):
         :type  launch_config: ``LaunchConfig`` object
         :param launch_config: A ``LaunchConfig`` object which
                describes advanced launch configuration options for an instance.
-               This includes block_device_mappings and network_interfaces. To
+               Currently, this includes only block_device_mappings. To
                construct a launch configuration object, call
                provider.compute.instances.create_launch_config()
 
@@ -935,7 +949,7 @@ class SecurityGroupService(PageableObjectMixin, CloudService):
         pass
 
     @abstractmethod
-    def create(self, name, description, network_id=None):
+    def create(self, name, description, network_id):
         """
         Create a new SecurityGroup.
 
@@ -946,9 +960,7 @@ class SecurityGroupService(PageableObjectMixin, CloudService):
         :param description: The description of the new security group.
 
         :type  network_id: ``str``
-        :param network_id: An optional network ID under which to create the
-                           security group that may be supported by some
-                           providers.
+        :param network_id: Network ID under which to create the security group.
 
         :rtype: ``object`` of :class:`.SecurityGroup`
         :return:  A SecurityGroup instance or ``None`` if one was not created.

--- a/cloudbridge/cloud/providers/aws/provider.py
+++ b/cloudbridge/cloud/providers/aws/provider.py
@@ -178,29 +178,27 @@ class MockAWSCloudProvider(AWSCloudProvider, TestMockHelperMixin):
     "family": "General Purpose",
     "enhanced_networking": false,
     "vCPU": 1,
-    "generation": "previous",
+    "generation": "current",
     "ebs_iops": 0,
     "network_performance": "Low",
     "ebs_throughput": 0,
     "vpc": {
-      "ips_per_eni": 4,
+      "ips_per_eni": 2,
       "max_enis": 2
     },
     "arch": [
-      "i386",
       "x86_64"
     ],
-    "linux_virtualization_types": [],
+    "linux_virtualization_types": [
+        "HVM"
+    ],
     "ebs_optimized": false,
-    "storage": {
-      "ssd": false,
-      "devices": 1,
-      "size": 160
-    },
+    "storage": null,
     "max_bandwidth": 0,
-    "instance_type": "t1.micro",
-    "ECU": 1.0,
-    "memory": 1.7
+    "instance_type": "t2.nano",
+    "ECU": "variable,
+    "memory": 0.5,
+    "ebs_max_bandwidth": 0
   }
 ]
 """

--- a/cloudbridge/cloud/providers/aws/resources.py
+++ b/cloudbridge/cloud/providers/aws/resources.py
@@ -609,6 +609,10 @@ class AWSSecurityGroup(BaseSecurityGroup):
         super(AWSSecurityGroup, self).__init__(provider, security_group)
 
     @property
+    def network_id(self):
+        return self._security_group.vpc_id
+
+    @property
     def rules(self):
         return [AWSSecurityGroupRule(self._provider, r, self)
                 for r in self._security_group.rules]
@@ -671,8 +675,8 @@ class AWSSecurityGroup(BaseSecurityGroup):
                rule.from_port == from_port and
                rule.to_port == to_port and
                rule.grants[0].cidr_ip == cidr_ip) or \
-               (rule.grants[0].name == src_group.name if src_group and
-               hasattr(rule.grants[0], 'name') else False):
+               (rule.grants[0].group_id == src_group.id if src_group and
+               hasattr(rule.grants[0], 'group_id') else False):
                 return AWSSecurityGroupRule(self._provider, rule, self)
         return None
 
@@ -681,6 +685,8 @@ class AWSSecurityGroup(BaseSecurityGroup):
         js = {k: v for(k, v) in attr if not k.startswith('_')}
         json_rules = [r.to_json() for r in self.rules]
         js['rules'] = [json.loads(r) for r in json_rules]
+        if js.get('network_id'):
+            js.pop('network_id')  # Omit for consistency across cloud providers
         return json.dumps(js, sort_keys=True)
 
 
@@ -725,9 +731,9 @@ class AWSSecurityGroupRule(BaseSecurityGroupRule):
     @property
     def group(self):
         if len(self._rule.grants) > 0:
-            if self._rule.grants[0].name:
+            if self._rule.grants[0].group_id:
                 cg = self._provider.ec2_conn.get_all_security_groups(
-                    groupnames=[self._rule.grants[0].name])[0]
+                    group_ids=[self._rule.grants[0].group_id])[0]
                 return AWSSecurityGroup(self._provider, cg)
         return None
 
@@ -742,6 +748,9 @@ class AWSSecurityGroupRule(BaseSecurityGroupRule):
         if self.group:
             # pylint:disable=protected-access
             self.parent._security_group.revoke(
+                ip_protocol=self.ip_protocol,
+                from_port=self.from_port,
+                to_port=self.to_port,
                 src_group=self.group._security_group)
         else:
             # pylint:disable=protected-access
@@ -1134,17 +1143,3 @@ class AWSLaunchConfig(BaseLaunchConfig):
 
     def __init__(self, provider):
         super(AWSLaunchConfig, self).__init__(provider)
-
-    def add_network_interface(self, net_id):
-        """
-        Extract a subnet within the network identified by ``net_id``.
-
-        AWS requires a subnet ID to be supplied vs. a network (i.e., VPC) ID
-        so just pull out one subnet within the network (currently, the first
-        one).
-        """
-        net = self.provider.network.get(net_id)
-        sns = net.subnets()
-        if sns:
-            sn = sns[0]
-        self.network_interfaces.append(sn.id)

--- a/cloudbridge/cloud/providers/aws/services.py
+++ b/cloudbridge/cloud/providers/aws/services.py
@@ -23,11 +23,11 @@ from cloudbridge.cloud.base.services import BaseSnapshotService
 from cloudbridge.cloud.base.services import BaseSubnetService
 from cloudbridge.cloud.base.services import BaseVolumeService
 from cloudbridge.cloud.interfaces.resources import InstanceType
-from cloudbridge.cloud.interfaces.resources \
+from cloudbridge.cloud.interfaces.exceptions \
     import InvalidConfigurationException
 from cloudbridge.cloud.interfaces.resources import KeyPair
 from cloudbridge.cloud.interfaces.resources import MachineImage
-# from cloudbridge.cloud.interfaces.resources import Network
+from cloudbridge.cloud.interfaces.resources import Network
 from cloudbridge.cloud.interfaces.resources import PlacementZone
 from cloudbridge.cloud.interfaces.resources import SecurityGroup
 from cloudbridge.cloud.interfaces.resources import Snapshot
@@ -53,6 +53,7 @@ from .resources import AWSVolume
 import cloudbridge as cb
 # Uncomment to enable logging by default for this module
 # cb.set_stream_logger(__name__)
+
 
 class AWSSecurityService(BaseSecurityService):
 
@@ -107,7 +108,6 @@ class AWSKeyPairService(BaseKeyPairService):
         :rtype: ``list`` of :class:`.KeyPair`
         :return:  list of KeyPair objects
         """
-        cb.log.trace("Listing AWS key pairs.")
         key_pairs = [AWSKeyPair(self.provider, kp)
                      for kp in self.provider.ec2_conn.get_all_key_pairs()]
         return ClientPagedResultList(self.provider, key_pairs,
@@ -171,7 +171,7 @@ class AWSSecurityGroupService(BaseSecurityGroupService):
         return ClientPagedResultList(self.provider, sgs,
                                      limit=limit, marker=marker)
 
-    def create(self, name, description, network_id=None):
+    def create(self, name, description, network_id):
         """
         Create a new SecurityGroup.
 
@@ -182,8 +182,8 @@ class AWSSecurityGroupService(BaseSecurityGroupService):
         :param description: The description of the new security group.
 
         :type  network_id: ``str``
-        :param network_id: The ID of the VPC to create the security group in,
-                           if any.
+        :param network_id: The ID of the VPC under which to create the security
+                           group.
 
         :rtype: ``object`` of :class:`.SecurityGroup`
         :return:  A SecurityGroup instance or ``None`` if one was not created.
@@ -467,31 +467,24 @@ class AWSInstanceService(BaseInstanceService):
     def __init__(self, provider):
         super(AWSInstanceService, self).__init__(provider)
 
-    def create(self, name, image, instance_type, zone=None,
+    def create(self, name, image, instance_type, network=None, zone=None,
                key_pair=None, security_groups=None, user_data=None,
-               launch_config=None,
-               **kwargs):
-        """
-        Creates a new virtual machine instance.
-
-        If no VPC/subnet was specified (via ``launch_config`` parameter), this
-        method will search for a default VPC and attempt to launch an instance
-        into that VPC.
-        """
+               launch_config=None, **kwargs):
         image_id = image.id if isinstance(image, MachineImage) else image
         instance_size = instance_type.id if \
             isinstance(instance_type, InstanceType) else instance_type
+        network_id = network.id if isinstance(network, Network) else network
         zone_id = zone.id if isinstance(zone, PlacementZone) else zone
         key_pair_name = key_pair.name if isinstance(
             key_pair,
             KeyPair) else key_pair
         if launch_config:
             bdm = self._process_block_device_mappings(launch_config, zone_id)
-            subnet_id = self._get_net_id(launch_config)
         else:
-            bdm = subnet_id = None
+            bdm = None
+
         subnet_id, zone_id, security_group_ids = \
-            self._resolve_launch_options(subnet_id, zone_id, security_groups)
+            self._resolve_launch_options(zone_id, network_id, security_groups)
 
         reservation = self.provider.ec2_conn.run_instances(
             image_id=image_id, instance_type=instance_size,
@@ -505,113 +498,202 @@ class AWSInstanceService(BaseInstanceService):
             instance.name = name
         return instance
 
-    def _resolve_launch_options(self, subnet_id, zone_id, security_groups):
+    def _resolve_launch_options(self, zone_id=None, vpc_id=None,
+                                security_groups=None):
         """
-        Resolve inter-dependent launch options.
+        Work out interdependent launch options.
 
-        With launching into VPC only, try to figure out a default
-        VPC to launch into, making placement decisions along the way that
-        are implied from the zone a subnet exists in.
-        """
-        def _deduce_subnet_and_zone(vpc, zone_id=None):
-            """
-            Figure out subnet ID from a VPC (and zone_id, if not supplied).
-            """
-            if zone_id:
-                # A placement zone was specified. Choose the default
-                # subnet in that zone.
-                for sn in vpc.subnets():
-                    if sn._subnet.availability_zone == zone_id:
-                        subnet_id = sn.id
-            else:
-                # No zone was requested, so just pick one subnet
-                sn = vpc.subnets()[0]
-                subnet_id = sn.id
-                zone_id = sn._subnet.availability_zone
-            return subnet_id, zone_id
+        Some launch options are required and interdependent so work through
+        those constraints. There are 8 subsets of options so the logic works
+        through each of those combinations to figure out the proper launch
+        options.
 
-        vpc_id = None
-        sg_ids = []
-        if subnet_id:
-            # Subnet was supplied - get the VPC so named SGs can be resolved
-            subnet = self.provider.vpc_conn.get_all_subnets(subnet_id)[0]
-            vpc_id = subnet.vpc_id
-            # zone_id must match zone where the requested subnet lives
-            if zone_id and subnet.availability_zone != zone_id:
-                raise ValueError("Requested placement zone ({0}) must match "
-                                 "specified subnet's availability zone ({1})."
-                                 .format(zone_id, subnet.availability_zone))
-        if security_groups:
-            # Try to get a subnet via specified SGs. This will work only if
-            # the specified SGs are within a VPC (which is a prerequisite to
-            # launch into VPC anyhow).
-            _sg_ids = self._process_security_groups(security_groups, vpc_id)
-            # Must iterate through all the SGs here because a SG name may
-            # exist in a VPC or EC2-Classic so opt for the VPC SG. This
-            # applies in the case no subnet was specified.
-            if not subnet_id:
-                for sg_id in _sg_ids:
-                    sg = self.provider.security.security_groups.get(sg_id)
-                    if sg._security_group.vpc_id:
-                        if sg_ids and sg_id not in sg_ids:
-                            raise ValueError("Multiple matches for VPC "
-                                             "security group(s) {0}."
-                                             .format(security_groups))
-                        else:
-                            sg_ids.append(sg_id)
-                        vpc = self.provider.network.get(
-                            sg._security_group.vpc_id)
-                        subnet_id, zone_id = _deduce_subnet_and_zone(
-                            vpc, zone_id)
-            else:
-                sg_ids = _sg_ids
-            if not subnet_id:
-                raise AttributeError("Supplied security group(s) ({0}) must "
-                                     "be associated with a VPC."
-                                     .format(security_groups))
-        if not subnet_id and not security_groups:
-            # No VPC/subnet was supplied, search for the default VPC.
-            for vpc in self.provider.network.list():
-                if vpc._vpc.is_default:
-                    vpc_id = vpc.id
-                    subnet_id, zone_id = _deduce_subnet_and_zone(vpc, zone_id)
-            if not vpc_id:
-                raise AttributeError("No default VPC exists. Supply a "
-                                     "subnet to launch into (via "
-                                     "launch_config param).")
-        return subnet_id, zone_id, sg_ids
-
-    def _process_security_groups(self, security_groups, vpc_id=None):
-        """
-        Process security groups to create a list of SG ID's for launching.
-
-        :type security_groups: A ``list`` of ``SecurityGroup`` objects or a
-                               list of ``str`` names
-        :param security_groups: A list of ``SecurityGroup`` objects or a list
-                                of ``SecurityGroup`` names, which should be
-                                assigned to this instance.
+        :type zone_id: ``str``
+        :param zone_id: ID of the zone where the launch should happen.
 
         :type vpc_id: ``str``
-        :param vpc_id: A VPC ID within which the supplied security groups exist
+        :param vpc_id: ID of the network within which to launch.
 
-        :rtype: ``list``
-        :return: A list of security group IDs.
+        :type security_groups: ``list`` of ``str``
+        :param zone_id: List of security group names.
+
+        :rtype: triplet of ``str``
+        :return: Subnet ID, zone ID and security group IDs for launch.
+
+        :raise ValueError: In case a conflicting combination is found or the
+                           method cannot infer the defaults, raise.
         """
-        if isinstance(security_groups, list) and \
-                isinstance(security_groups[0], SecurityGroup):
-            sg_ids = [sg.id for sg in security_groups]
-        else:
-            # SG names were supplied, need to map them to SG IDs.
-            sg_ids = []
-            # If a VPC was specified, need to map to the SGs in the VPC.
-            flters = None
-            if vpc_id:
-                flters = {'vpc_id': vpc_id}
-            sgs = self.provider.ec2_conn.get_all_security_groups(
-                filters=flters)
-            sg_ids = [sg.id for sg in sgs if sg.name in security_groups]
+        def _get_default_vpc(vpcs, exc="No default network found."):
+            """
+            Inspect supplied VPCs to figure out a default one or create one.
 
-        return sg_ids
+            Default VPC either has ``is_default`` property set or matches the
+            default network name used by this library. If a default network
+            is not found, an attempt to create one is made.
+
+            :type vpcs: ``list``
+            :param vpcs: A list of boto VPC objects.
+
+            :type exc: ``str``
+            :type exc: A string value to use if/when raising ValueError.
+
+            :rtype: ``str``
+            :return: Default VPC ID.
+            """
+            default_vpc = None
+            for vpc in vpcs:
+                if vpc.is_default:
+                    default_vpc = vpc.id
+                    break
+            if not default_vpc:
+                for vpc in vpcs:
+                    if vpc.tags.get('Name', '') == \
+                       AWSNetwork.CB_DEFAULT_NETWORK_NAME:
+                        default_vpc = vpc.id
+                        break
+            if not default_vpc:
+                net = self.provider.network.create(
+                    name=AWSNetwork.CB_DEFAULT_NETWORK_NAME)
+                default_vpc = net.id
+            return default_vpc
+
+        def _get_potential_subnets(filters, exc):
+            """
+            Query existing subnets through supplied filters.
+
+            :type filters: ``dict``
+            :param filters: A dictionary supplying desired filters.
+
+            :type exc: ``str``
+            :type exc: A string value to use if/when raising ValueError.
+
+            :rtype: tuple of ``str``
+            :return: A tuple with a random subnet that matches supplied
+                     filters and an availability zone where the given subnet
+                     is defined.
+
+            :raise ValueError: If no subnet can be found, raise a ValueError.
+            """
+            potential_subnets = self.provider.vpc_conn.get_all_subnets(
+                filters=filters)
+            if potential_subnets and len(potential_subnets) > 0:
+                sn_id = potential_subnets[0].id
+                zone_id = potential_subnets[0].availability_zone
+            else:
+                raise ValueError(exc)
+            return sn_id, zone_id
+
+        def _get_security_groups(security_groups, vpc_id=None, obj=False):
+            """
+            Resolve exact security groups to use.
+
+            :type security_groups: A ``list`` of ``SecurityGroup`` objects or
+                                   a list of ``str`` names.
+            :param security_groups: A list of ``SecurityGroup`` objects or a
+                                    list of ``SecurityGroup`` names, which
+                                    should be resolved.
+
+            :type vpc_id: ``str``
+            :param vpc_id: ID of the network within which to launch.
+
+            :type obj: ``bool``
+            :param obj: If True, return provider-native security group objects.
+                        Otherwise, return the IDs.
+
+            :rtype: list
+            :return: provider-native security group objects or the IDs (see
+                    ``obj`` param).
+            """
+            if isinstance(security_groups, list) and \
+               isinstance(security_groups[0], SecurityGroup):
+                return [sg._security_group if obj else sg.id
+                        for sg in security_groups]
+            else:
+                flters = {'group_name': security_groups}
+                if vpc_id:
+                    flters['vpc_id'] = vpc_id
+                sgs = self.provider.ec2_conn.get_all_security_groups(
+                    filters=flters)
+                return list(set([sg if obj else sg.id for sg in sgs]))
+
+        if zone_id and vpc_id and security_groups:
+            exc = "No subnets found in zone {0} for network {1}.".format(
+                zone_id, vpc_id)
+            flters = {'availabilityZone': zone_id, 'state': 'available',
+                      'vpcId': vpc_id}
+            sn_id, _ = _get_potential_subnets(flters, exc)
+            sg_ids = _get_security_groups(security_groups, vpc_id)
+        elif vpc_id and security_groups:
+            sg_ids = _get_security_groups(security_groups, vpc_id)
+            exc = "No subnets found in network {0}.".format(vpc_id)
+            flters = {'state': 'available', 'vpcId': vpc_id}
+            sn_id, zone_id = _get_potential_subnets(flters, exc)
+        elif vpc_id and zone_id:
+            flters = {'availabilityZone': zone_id, 'state': 'available',
+                      'vpcId': vpc_id}
+            exc = "No subnets found in zone {0} for network {1}.".format(
+                zone_id, vpc_id)
+            sn_id, _ = _get_potential_subnets(flters, exc)
+            sg_ids = None
+        elif zone_id and security_groups:
+            sgs = _get_security_groups(security_groups, obj=True)
+            # Get VPCs the supplied SGs belong to
+            vpc_ids = list(set([sg.vpc_id for sg in sgs if sg.vpc_id]))
+            vpcs = []
+            if vpc_ids:
+                vpcs = self.provider.vpc_conn.get_all_vpcs(vpc_ids=vpc_ids)
+            exc = ("No default network found for zone {0} and security groups "
+                   "{1}".format(zone_id, security_groups))
+            default_vpc = _get_default_vpc(vpcs, exc)
+            # Filter only the SGs within the default VPC
+            sg_ids = _get_security_groups(security_groups, default_vpc)
+            flters = {'availabilityZone': zone_id, 'state': 'available',
+                      'vpc_id': default_vpc}
+            exc = "No subnets found in zone {0} for default network {1}." \
+                .format(zone_id, default_vpc)
+            sn_id, _ = _get_potential_subnets(flters, exc)
+        elif vpc_id:
+            flters = {'state': 'available', 'vpcId': vpc_id}
+            exc = "No subnets found for network {0}.".format(vpc_id)
+            sn_id, zone_id = _get_potential_subnets(flters, exc)
+            sg_ids = None
+        elif zone_id:
+            vpcs = self.provider.vpc_conn.get_all_vpcs()
+            exc = "No default network exists for security zone {0}.".format(
+                zone_id)
+            default_vpc = _get_default_vpc(vpcs, exc)
+            flters = {'availabilityZone': zone_id, 'state': 'available',
+                      'vpcId': default_vpc}
+            exc = "No subnets found in zone {0} for default network {1}." \
+                .format(zone_id, default_vpc)
+            sn_id, _ = _get_potential_subnets(flters, exc)
+            sg_ids = None
+        elif security_groups:
+            sgs = _get_security_groups(security_groups, obj=True)
+            # Get VPCs the supplied SGs belong to
+            vpc_ids = list(set([sg.vpc_id for sg in sgs if sg.vpc_id]))
+            vpcs = []
+            if vpc_ids:
+                vpcs = self.provider.vpc_conn.get_all_vpcs(vpc_ids=vpc_ids)
+            exc = "No default network exists for security groups {0}.".format(
+                security_groups)
+            default_vpc = _get_default_vpc(vpcs, exc)
+            # Filter only the SGs within the default VPC
+            sg_ids = _get_security_groups(security_groups, default_vpc)
+            flters = {'state': 'available', 'vpcId': default_vpc}
+            exc = "No subnets found in network {0}.".format(default_vpc)
+            sn_id, zone_id = _get_potential_subnets(flters, exc)
+        else:
+            # Nothing was defined, use all defaults
+            vpcs = self.provider.vpc_conn.get_all_vpcs()
+            default_vpc = _get_default_vpc(vpcs)
+            flters = {'state': 'available', 'vpcId': default_vpc}
+            exc = "No subnets found for default network {1}.".format(
+                default_vpc)
+            sn_id, zone_id = _get_potential_subnets(flters, exc)
+            sg_ids = None
+
+        return sn_id, zone_id, sg_ids
 
     def _process_block_device_mappings(self, launch_config, zone=None):
         """
@@ -663,11 +745,6 @@ class AWSInstanceService(BaseInstanceService):
                 bd_type.ephemeral_name = 'ephemeral%s' % ephemeral_counter
 
         return bdm
-
-    def _get_net_id(self, launch_config):
-        return (launch_config.network_interfaces[0]
-                if len(launch_config.network_interfaces) > 0
-                else None)
 
     def create_launch_config(self):
         return AWSLaunchConfig(self.provider)
@@ -729,6 +806,15 @@ class AWSInstanceTypesService(BaseInstanceTypesService):
     @property
     def instance_data(self):
         """
+        Fetch info about the available instances.
+
+        To update this information, update the file pointed to by the
+        ``AWS_INSTANCE_DATA_DEFAULT_URL`` above. The content for this file
+        should be obtained from this repo
+        https://github.com/powdahound/ec2instances.info (in particular, this
+        file: https://raw.githubusercontent.com/powdahound/ec2instances.info/
+        master/www/instances.json).
+
         TODO: Needs a caching function with timeout
         """
         r = requests.get(self.provider.config.get(
@@ -785,8 +871,8 @@ class AWSNetworkService(BaseNetworkService):
                                      limit=limit, marker=marker)
 
     def create(self, name=None):
-        # AWS requried CIDR block to be specified when creating a network
-        # so set a default one and use the largest possible netmask.
+        # AWS requires CIDR block to be specified when creating a network
+        # so set a default one and use the largest allowed netmask.
         default_cidr = '10.0.0.0/16'
         network = self.provider.vpc_conn.create_vpc(cidr_block=default_cidr)
         cb_network = AWSNetwork(self.provider, network)

--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -1,13 +1,10 @@
-"""
-Provider implementation based on OpenStack Python clients for OpenStack
-compatible clouds.
-"""
+"""Provider implementation based on OpenStack Python clients for OpenStack."""
 
 import os
 
 from cinderclient import client as cinder_client
+from keystoneauth1 import session
 from keystoneclient import client as keystone_client
-from keystoneclient import session
 from neutronclient.v2_0 import client as neutron_client
 from novaclient import client as nova_client
 from novaclient import shell as nova_shell
@@ -23,6 +20,7 @@ from .services import OpenStackSecurityService
 
 
 class OpenStackCloudProvider(BaseCloudProvider):
+    """OpenStack provider implementation."""
 
     PROVIDER_ID = 'openstack'
 
@@ -35,14 +33,13 @@ class OpenStackCloudProvider(BaseCloudProvider):
             'os_username', os.environ.get('OS_USERNAME', None))
         self.password = self._get_config_value(
             'os_password', os.environ.get('OS_PASSWORD', None))
-        self.tenant_name = self._get_config_value(
-            'os_tenant_name', os.environ.get('OS_TENANT_NAME', None))
+        self.project_name = self._get_config_value(
+            'os_project_name', os.environ.get('OS_PROJECT_NAME', None) or
+            os.environ.get('OS_TENANT_NAME', None))
         self.auth_url = self._get_config_value(
             'os_auth_url', os.environ.get('OS_AUTH_URL', None))
         self.region_name = self._get_config_value(
             'os_region_name', os.environ.get('OS_REGION_NAME', None))
-        self.project_name = self._get_config_value(
-            'os_project_name', os.environ.get('OS_PROJECT_NAME', None))
         self.project_domain_name = self._get_config_value(
             'os_project_domain_name',
             os.environ.get('OS_PROJECT_DOMAIN_NAME', None))
@@ -51,23 +48,6 @@ class OpenStackCloudProvider(BaseCloudProvider):
         self.identity_api_version = self._get_config_value(
             'os_identity_api_version',
             os.environ.get('OS_IDENTITY_API_VERSION', None))
-        # Allow individual service connections to have their own values but
-        # default to a the ones defined above.
-        self.swift_username = self._get_config_value(
-            'os_swift_username',
-            os.environ.get('OS_SWIFT_USERNAME', self.username))
-        self.swift_password = self._get_config_value(
-            'os_swift_password',
-            os.environ.get('OS_SWIFT_PASSWORD', self.password))
-        self.swift_tenant_name = self._get_config_value(
-            'os_swift_tenant_name',
-            os.environ.get('OS_SWIFT_TENANT_NAME', self.tenant_name))
-        self.swift_auth_url = self._get_config_value(
-            'os_swift_auth_url',
-            os.environ.get('OS_SWIFT_AUTH_URL', self.auth_url))
-        self.swift_region_name = self._get_config_value(
-            'os_swift_region_name',
-            os.environ.get('OS_SWIFT_REGION_NAME', self.region_name))
 
         # Service connections, lazily initialized
         self._nova = None
@@ -76,6 +56,9 @@ class OpenStackCloudProvider(BaseCloudProvider):
         self._cinder = None
         self._swift = None
         self._neutron = None
+
+        # Additional cached variables
+        self._cached_keystone_session = None
 
         # Initialize provider services
         self._compute = OpenStackComputeService(self)
@@ -114,27 +97,28 @@ class OpenStackCloudProvider(BaseCloudProvider):
         """
         Connect to Keystone and return a session object.
 
-        :rtype: :class:`keystoneclient.session.Session`
+        :rtype: :class:`keystoneauth1.session.Session`
         :return: A Keystone session object.
         """
-        def connect_v2():
-            from keystoneclient.auth.identity import Password as Password_v2
-            auth = Password_v2(self.auth_url, username=self.username,
-                               password=self.password,
-                               tenant_name=self.tenant_name)
-            return session.Session(auth=auth)
+        if self._cached_keystone_session:
+            return self._cached_keystone_session
 
-        def connect_v3():
-            from keystoneclient.auth.identity.v3 import Password as Password_v3
+        if self._keystone_version == 3:
+            from keystoneauth1.identity.v3 import Password as Password_v3
             auth = Password_v3(auth_url=self.auth_url,
                                username=self.username,
                                password=self.password,
                                user_domain_name=self.user_domain_name,
                                project_domain_name=self.project_domain_name,
                                project_name=self.project_name)
-            return session.Session(auth=auth)
-
-        return connect_v3() if self._keystone_version == 3 else connect_v2()
+            self._cached_keystone_session = session.Session(auth=auth)
+        else:
+            from keystoneauth1.identity.v2 import Password as Password_v2
+            auth = Password_v2(self.auth_url, username=self.username,
+                               password=self.password,
+                               tenant_name=self.project_name)
+            self._cached_keystone_session = session.Session(auth=auth)
+        return self._cached_keystone_session
 
 #     @property
 #     def glance(self):
@@ -184,29 +168,9 @@ class OpenStackCloudProvider(BaseCloudProvider):
         return self._connect_nova_region(self.region_name)
 
     def _connect_nova_region(self, region_name):
-        """
-        Get an OpenStack Nova (compute) client object for the given cloud.
-        """
-        def connect_pwd():
-            """
-            Connect using username and password parameters.
-            """
-            nova = nova_client.Client(
-                api_version, username=self.username, api_key=self.password,
-                project_id=self.tenant_name, auth_url=self.auth_url,
-                region_name=region_name, service_name=service_name,
-                http_log_debug=True if self.config.debug_mode else False)
-            nova.authenticate()
-            return nova
-
-        def connect_sess():
-            """
-            Connect using a Keystone session object.
-            """
-            return nova_client.Client(
-                api_version, session=self._keystone_session,
-                service_name=service_name,
-                http_log_debug=True if self.config.debug_mode else False)
+        """Get an OpenStack Nova (compute) client object."""
+        # Force reauthentication with Keystone
+        self._cached_keystone_session = None
 
         api_version = self._get_config_value(
             'os_compute_api_version',
@@ -218,13 +182,20 @@ class OpenStackCloudProvider(BaseCloudProvider):
         if self.config.debug_mode:
             nova_shell.OpenStackComputeShell().setup_debugging(True)
 
-        return connect_sess() if self._keystone_version == 3 else connect_pwd()
+        nova = nova_client.Client(
+                api_version, session=self._keystone_session,
+                auth_url=self.auth_url,
+                region_name=region_name,
+                service_name=service_name,
+                http_log_debug=True if self.config.debug_mode else False)
+        return nova
 
     def _connect_keystone(self):
-        """
-        Get an OpenStack Keystone (identity) client object for the given cloud.
-        """
-        def connect_v2():
+        """Get an OpenStack Keystone (identity) client object."""
+        if self._keystone_version == 3:
+            return keystone_client.Client(session=self._keystone_session,
+                                          auth_url=self.auth_url)
+        else:
             # Wow, the internal keystoneV2 implementation is terribly buggy. It
             # needs both a separate Session object and the username, password
             # again for things to work correctly. Plus, a manual call to
@@ -235,42 +206,21 @@ class OpenStackCloudProvider(BaseCloudProvider):
                 auth_url=self.auth_url,
                 username=self.username,
                 password=self.password,
-                tenant_name=self.tenant_name,
+                project_name=self.project_name,
                 region_name=self.region_name)
             keystone.authenticate()
             return keystone
 
-        def connect_v3():
-            return keystone_client.Client(session=self._keystone_session,
-                                          auth_url=self.auth_url)
-
-        return connect_v3() if self._keystone_version == 3 else connect_v2()
-
     def _connect_cinder(self):
-        """
-        Get an OpenStack Cinder (block storage) client object for the given
-        cloud.
-        """
-        def connect_pwd():
-            """
-            Connect using username and password parameters.
-            """
-            return cinder_client.Client(
-                api_version, username=self.username, api_key=self.password,
-                project_id=self.tenant_name, auth_url=self.auth_url)
-
-        def connect_sess():
-            """
-            Connect using a Keystone session object.
-            """
-            return cinder_client.Client(
-                api_version, session=self._keystone_session)
-
+        """Get an OpenStack Cinder (block storage) client object."""
         api_version = self._get_config_value(
             'os_volume_api_version',
             os.environ.get('OS_VOLUME_API_VERSION', 2))
 
-        return connect_sess() if self._keystone_version == 3 else connect_pwd()
+        return cinder_client.Client(api_version,
+                                    auth_url=self.auth_url,
+                                    session=self._keystone_session,
+                                    region_name=self.region_name)
 
 #     def _connect_glance(self):
 #         """
@@ -285,47 +235,12 @@ class OpenStackCloudProvider(BaseCloudProvider):
 #                                     session=self.keystone.session)
 
     def _connect_swift(self):
-        """
-        Get an OpenStack Swift (object store) client object for the given
-        cloud.
-        """
-        def connect_v2():
-            os_options = {'region_name': self.swift_region_name}
-            return swift_client.Connection(
-                authurl=self.swift_auth_url, auth_version='2',
-                user=self.swift_username, key=self.swift_password,
-                tenant_name=self.swift_tenant_name,
-                os_options=os_options)
-
-        def connect_v3():
-            os_options = {'region_name': self.swift_region_name,
-                          'user_domain_name': self.user_domain_name,
-                          'project_domain_name': self.project_domain_name,
-                          'project_name': self.project_name}
-            return swift_client.Connection(
-                authurl=self.swift_auth_url, auth_version='3',
-                user=self.swift_username, key=self.swift_password,
-                os_options=os_options)
-
-        return connect_v3() if self._keystone_version == 3 else connect_v2()
+        """Get an OpenStack Swift (object store) client object cloud."""
+        return swift_client.Connection(authurl=self.auth_url,
+                                       session=self._keystone_session)
 
     def _connect_neutron(self):
-        """
-        Get an OpenStack Neutron (networking) client object for the given
-        cloud.
-        """
-        def connect_pwd():
-            """
-            Connect using username and password parameters.
-            """
-            return neutron_client.Client(
-                username=self.username, password=self.password,
-                tenant_name=self.tenant_name, auth_url=self.auth_url)
-
-        def connect_sess():
-            """
-            Connect using a Keystone session object.
-            """
-            return neutron_client.Client(session=self._keystone_session)
-
-        return connect_sess() if self._keystone_version == 3 else connect_pwd()
+        """Get an OpenStack Neutron (networking) client object cloud."""
+        return neutron_client.Client(auth_url=self.auth_url,
+                                     session=self._keystone_session,
+                                     region_name=self.region_name)

--- a/cloudbridge/cloud/providers/openstack/resources.py
+++ b/cloudbridge/cloud/providers/openstack/resources.py
@@ -854,6 +854,15 @@ class OpenStackSecurityGroup(BaseSecurityGroup):
         super(OpenStackSecurityGroup, self).__init__(provider, security_group)
 
     @property
+    def network_id(self):
+        """
+        OpenStack does not associate a SG with a network so default to None.
+
+        :return: Always return ``None``.
+        """
+        return None
+
+    @property
     def rules(self):
         # Update SG object; otherwise, recently added rules do now show
         self._security_group = self._provider.nova.security_groups.get(

--- a/docs/topics/launch.rst
+++ b/docs/topics/launch.rst
@@ -1,110 +1,63 @@
 Launching instances
 ===================
-Depending on the cloud provider, instances can be launched using
-software-managed networking (e.g., VPC on AWS, Neutron on OpenStack) or the
-classic networking approach. Before being able to run below command, you will
-need a ``provider`` object (see `this page <setup.html>`_).
+Before being able to run below commands, you will need a ``provider`` object
+(see `this page <setup.html>`_).
 
 Common launch data
 ------------------
-Before launching an instance, you need to decide on what image to launch
-as well as what type of instance. We will create those objects here are use
-them in both options below. The specified image ID is a base Ubuntu image on
-AWS so feel free to change it as desired.
+Before launching an instance, you need to decide what image to launch
+as well as what type of instance. We will create those objects here. The
+specified image ID is a base Ubuntu image on AWS so feel free to change it as
+desired. For instance type, we're going to let CloudBridge figure out what's
+the appropriate name on a given provider for an instance with at least 2 CPUs
+and 4 GB RAM.
 
 .. code-block:: python
 
-    img = provider.compute.images.get('ami-d85e75b0')  # Ubuntu 14.04 on AWS
-    inst_type = provider.compute.instance_types.find(name='m1.small')[0]
+    img = provider.compute.images.get('ami-5ac2cd4d')  # Ubuntu 14.04 on AWS
+    inst_type = sorted([t for t in provider.compute.instance_types.list()
+                        if t.vcpus >= 2 and t.ram >= 4],
+                       key=lambda x: x.vcpus*x.ram)[0]
 
 When launching an instance, you can also specify several optional arguments
 such as the security group, a key pair, or instance user data. To allow you to
 connect to the launched instances, we will also supply those parameters (note
 that we're making an assumption here these resources exist; if you don't have
-those resources, take a look at the `Getting Started <../getting_started.html>`_
-guide).
+those resources under your account, take a look at the
+`Getting Started <../getting_started.html>`_ guide).
 
 .. code-block:: python
 
     kp = provider.security.key_pairs.find(name='cloudbridge_intro')[0]
     sg = provider.security.security_groups.list()[0]
 
-Private networking setup
-------------------------
-Private networking gives you control over the networking setup for your
-instance(s) and is considered the preferred method for launching instances.
-
-Create a new private network
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To start, we will create a private network and a corresponding subnet into
-which an instance will be launched. When creating the subnet, we need to
-set the address pool. For OpenStack, any address pool is acceptable while for
-the AWS cloud, the subnet address pool needs to belong to the private network
-address space; we can obtain the private network address space via
-network object's ``cidr_block`` field (e.g., ``10.0.0.0/16``). Let's crate a
-subnet starting from the beginning of the block and allow up to 32 IP addresses
-into the subnet (``/27``):
+Launch an instance
+------------------
+Once we have all the desired pieces, we'll use them to launch an instance:
 
 .. code-block:: python
 
-    net = provider.network.create(name="CloudBridge-net")
-    net.cidr_block  # '10.0.0.0/16'
-    sn = net.create_subnet('10.0.0.1/27', "CloudBridge-subnet")
+    inst = provider.compute.instances.create(
+        name='CloudBridge-VPC', image=img, instance_type=inst_type,
+        key_pair=kp, security_groups=[sg])
 
-Note that it may be necessary to also create a route for this new network. If
-that's the case, take a look at the
-`Getting Started <../getting_started.html>`_ document for an example.
-
-Retrieve an existing private network
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you already have existing networks, we can simply reuse an existing one:
+Private networking
+~~~~~~~~~~~~~~~~~~
+Private networking gives you control over the networking setup for your
+instance(s) and is considered the preferred method for launching instances. To
+launch an instance with an explicit private network, just supply it as an
+additional argument to the ``create`` method:
 
 .. code-block:: python
 
     provider.network.list()  # Find a desired network ID
     net = provider.network.get('desired network ID')
-    sn = net.subnets()[0]  # Get a handle on a desired subnet
-
-Launch an instance
-------------------
-Once we have a handle on a private network, we'll define a launch configuration
-object to aggregate all the launch configuration options. The launch config
-can contain other launch options, such as the block storage mappings (see
-below). Finally, we can launch the instance:
-
-.. code-block:: python
-
-    lc = provider.compute.instances.create_launch_config()
-    lc.add_network_interface(net.id)
     inst = provider.compute.instances.create(
-        name='CloudBridge-VPC', image=img,  instance_type=inst_type,
-        launch_config=lc, key_pair=kp, security_groups=[sg])
+        name='CloudBridge-VPC', image=img, instance_type=inst_type,
+        network=net, key_pair=kp, security_groups=[sg])
 
-.. warning::
-
-    CloudBridge version 0.1.0 does not uniformly deal with network abstractions
-    for AWS and OpenStack providers. AWS takes a subnet ID for it's launch
-    config while OpenStack takes a network ID. As a result, the user needs to
-    make this distinction in their code and supply the correct value. For
-    example, for AWS, above code needs to look like the following:
-    ``lc.add_network_interface(sn.id)``. This has been corrected in newer code.
-
-Launch with default networking
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Launching an instance with the default networking model is straightforward,
-only needing to specify the basic parameters. This will only work for the case
-a default network exists for your account, which is provider-dependent and may
-not necessarily exist.
-
-For the case of AWS, an instance will be launched into the VPC where the
-specified security group belongs to. If no security group is specified, the
-instance will get launched into the *default* VPC, assuming such VPC exists.
-
-.. code-block:: python
-
-    inst = provider.compute.instances.create(
-        name='CloudBridge-basic', image=img, instance_type=inst_type,
-        key_pair=kp, security_groups=[sg])
+For more information on how to create and setup a private network, take a look
+at `Networking <./networking.html>`_.
 
 Block device mapping
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/topics/networking.rst
+++ b/docs/topics/networking.rst
@@ -1,0 +1,50 @@
+Private networking
+==================
+Private networking gives you control over the networking setup for your
+instance(s) and is considered the preferred method for launching instances.
+Also, providers these days are increasingly requiring use of private networks.
+
+If you do not explicitly specify a private network to use when launching an
+instance, CloudBridge will attempt to use a default one. A 'default' network is
+one tagged as such by the native API. If such tag or functionality does not
+exist, CloudBridge will look for one with a predefined name (by default, called
+'CloudBridgeNet', which can be overridden with environment variable
+``CB_DEFAULT_NETWORK_NAME``).
+
+Create a new private network
+----------------------------
+Creating a private network is a simple, one-line command but appropriately
+connecting it so it has Internet access is a multi-step process:
+(1) create a network; (2) create a subnet within the network; (3) create a
+router; (4) attach the router to an external network; and (5) add a route to
+the router that links with with a subnet. For some providers, any network can
+be external (ie, connected to the Internet) while for others it's a specific,
+pre-defined one that exists in the an account by default. In order to properly
+connect the router, we need to ensure we're using an external network.
+
+When creating the subnet, we need to set an address pool. We can obtain the
+private network address space via network object's ``cidr_block`` field (e.g.,
+``10.0.0.0/16``). Below, we'll create a subnet starting from the beginning of
+the block and allow up to 16 IP addresses into the subnet (``/28``).
+
+.. code-block:: python
+
+    net = provider.network.create('cloudbridge_intro')
+    sn = net.create_subnet('10.0.0.0/28', 'cloudbridge-intro')
+    router = provider.network.create_router('cloudbridge-intro')
+    if not net.external:
+        for n in self.provider.network.list():
+            if n.external:
+                external_net = n
+                break
+    router.attach_network(external_net.id)
+    router.add_route(sn.id)
+
+Retrieve an existing private network
+------------------------------------
+If you already have existing networks, we can query for those:
+
+.. code-block:: python
+
+    provider.network.list()  # Find a desired network ID
+    net = provider.network.get('desired network ID')

--- a/docs/topics/overview.rst
+++ b/docs/topics/overview.rst
@@ -8,6 +8,7 @@ Introductions to all the key parts of CloudBridge you'll need to know:
     How to install CloudBridge <install.rst>
     Connection and authentication setup <setup.rst>
     Launching instances <launch.rst>
+    Networking <networking.rst>
     Object states and lifecycles <object_lifecycles.rst>
     Paging and iteration <paging_and_iteration.rst>
     Using block storage <block_storage.rst>

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -28,28 +28,9 @@ Mandatory variables  Optional Variables
 OS_AUTH_URL			 NOVA_SERVICE_NAME
 OS_USERNAME			 OS_COMPUTE_API_VERSION
 OS_PASSWORD			 OS_VOLUME_API_VERSION
-OS_TENANT_NAME
+OS_PROJECT_NAME
 OS_REGION_NAME
 ===================  ==================
-
-If you'd like, you can specify service-specific variables for OpenStack.
-This can be used to create a multi-cloud provider object for example where
-the compute service is using one cloud while the object store service uses
-another. This can be useful is a given cloud does not supply all the desired
-services. If these variables are not supplied, the default ones from above
-are used across all OpenStack services.
-
-=================================== ==============
-Optional service-specific variables Example values
------------------------------------ --------------
-Swift service
-==================================================
-OS_SWIFT_AUTH_URL                   https://keystone.rc.nectar.org.au:5000/v2.0/
-OS_SWIFT_USERNAME                   your.name@example.com
-OS_SWIFT_PASSWORD                   GcsGgcbsdilcbUIYGcsdc
-OS_SWIFT_REGION_NAME                RegionOne
-OS_SWIFT_TENANT_NAME                GalaxyProject
-=================================== ==============
 
 
 Once the environment variables are set, you can create a connection as follows:

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,12 @@ with open(os.path.join('cloudbridge', '__init__.py')) as f:
             break
 
 base_reqs = ['bunch>=1.0.1', 'six>=1.10.0', 'retrying>=1.3.3']
-openstack_reqs = ['python-novaclient>=2.33.0',
-                  'python-glanceclient',
-                  'python-cinderclient>=1.4.0',
-                  'python-swiftclient>=2.6.0',
-                  'python-neutronclient>=3.1.0',
-                  'python-keystoneclient>=2.0.0']
+openstack_reqs = ['python-novaclient>=7.0.0',
+                  'python-glanceclient>=2.5.0',
+                  'python-cinderclient>=1.9.0',
+                  'python-swiftclient>=3.2.0',
+                  'python-neutronclient>=6.0.0',
+                  'python-keystoneclient>=3.8.0']
 aws_reqs = ['boto>=2.38.0']
 gce_reqs = ['google-api-python-client>=1.4.2', "pycrypto"]
 full_reqs = base_reqs + aws_reqs + openstack_reqs + gce_reqs

--- a/test/test_compute_service.py
+++ b/test/test_compute_service.py
@@ -6,7 +6,7 @@ from cloudbridge.cloud.interfaces \
     import InvalidConfigurationException
 from cloudbridge.cloud.interfaces import InstanceState
 from cloudbridge.cloud.interfaces.resources import InstanceType
-from cloudbridge.cloud.interfaces.resources import WaitStateException
+from cloudbridge.cloud.interfaces.exceptions import WaitStateException
 from test.helpers import ProviderTestBase
 import test.helpers as helpers
 
@@ -287,14 +287,13 @@ class CloudComputeServiceTestCase(ProviderTestBase):
             lc.add_ephemeral_device()
 
         net, _ = helpers.create_test_network(self.provider, name)
-        lc.add_network_interface(net.id)
 
         inst = helpers.create_test_instance(
             self.provider,
             name,
-            zone=helpers.get_provider_test_data(
-                self.provider,
-                'placement'),
+            network=net,
+            # We don't have a way to match the test net placement and this zone
+            # zone=helpers.get_provider_test_data(self.provider, 'placement'),
             launch_config=lc)
 
         def cleanup(instance, net):

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,6 +1,10 @@
+import unittest
 import cloudbridge
 from cloudbridge.cloud import interfaces
 from test.helpers import ProviderTestBase
+from cloudbridge.cloud.interfaces.exceptions import ProviderConnectionException
+from cloudbridge.cloud.interfaces import TestMockHelperMixin
+from cloudbridge.cloud.factory import CloudProviderFactory
 
 
 class CloudInterfaceTestCase(ProviderTestBase):
@@ -38,3 +42,25 @@ class CloudInterfaceTestCase(ProviderTestBase):
         """
         self.assertIsNotNone(cloudbridge.get_version(),
                              "Did not get library version.")
+
+    def test_authenticate_success(self):
+        self.assertTrue(self.provider.authenticate())
+
+    def test_authenticate_failure(self):
+        if isinstance(self.provider, TestMockHelperMixin):
+            raise unittest.SkipTest(
+                "Mock providers are not expected to"
+                " authenticate correctly")
+
+        cloned_provider = CloudProviderFactory().create_provider(
+            self.provider.PROVIDER_ID, self.provider.config)
+
+        with self.assertRaises(ProviderConnectionException):
+            # Mock up test by clearing credentials on a per provider basis
+            if cloned_provider.PROVIDER_ID == 'aws':
+                cloned_provider.a_key = "dummy_a_key"
+                cloned_provider.s_key = "dummy_s_key"
+            elif cloned_provider.PROVIDER_ID == 'openstack':
+                cloned_provider.username = "cb_dummy"
+                cloned_provider.password = "cb_dummy"
+            cloned_provider.authenticate()

--- a/test/test_object_life_cycle.py
+++ b/test/test_object_life_cycle.py
@@ -1,7 +1,7 @@
 import uuid
 
 from cloudbridge.cloud.interfaces import VolumeState
-from cloudbridge.cloud.interfaces.resources import WaitStateException
+from cloudbridge.cloud.interfaces.exceptions import WaitStateException
 from test.helpers import ProviderTestBase
 import test.helpers as helpers
 

--- a/test/test_security_service.py
+++ b/test/test_security_service.py
@@ -14,7 +14,7 @@ class CloudSecurityServiceTestCase(ProviderTestBase):
             methodName=methodName, provider=provider)
 
     def test_crud_key_pair_service(self):
-        name = 'cbtestkeypair-a'
+        name = 'cbtestkeypairA-{0}'.format(uuid.uuid4()).lower()
         kp = self.provider.security.key_pairs.create(name=name)
         with helpers.cleanup_action(
             lambda:
@@ -65,7 +65,7 @@ class CloudSecurityServiceTestCase(ProviderTestBase):
             "Found a key pair {0} that should not exist?".format(no_kp))
 
     def test_key_pair(self):
-        name = 'cbtestkeypair-b'
+        name = 'cbtestkeypairB-{0}'.format(uuid.uuid4()).lower()
         kp = self.provider.security.key_pairs.create(name=name)
         with helpers.cleanup_action(lambda: kp.delete()):
             kpl = self.provider.security.key_pairs.list()
@@ -101,7 +101,7 @@ class CloudSecurityServiceTestCase(ProviderTestBase):
             self.provider.security.security_groups.delete(group_id=sg.id)
 
     def test_crud_security_group_service(self):
-        name = 'cbtestsecuritygroup-a'
+        name = 'cbtestsecuritygroupA-{0}'.format(uuid.uuid4()).lower()
         net = self.provider.network.create(name=name)
         sg = self.provider.security.security_groups.create(
             name=name, description=name, network_id=net.id)
@@ -157,7 +157,7 @@ class CloudSecurityServiceTestCase(ProviderTestBase):
 
     def test_security_group(self):
         """Test for proper creation of a security group."""
-        name = 'cbtestsecuritygroup-b'
+        name = 'cbtestsecuritygroupB-{0}'.format(uuid.uuid4()).lower()
         net = self.provider.network.create(name=name)
         sg = self.provider.security.security_groups.create(
             name=name, description=name, network_id=net.id)
@@ -207,7 +207,7 @@ class CloudSecurityServiceTestCase(ProviderTestBase):
 
     def test_security_group_rule_add_twice(self):
         """Test whether adding the same rule twice succeeds."""
-        name = 'cbtestsecuritygroupB-{0}'.format(uuid.uuid4())
+        name = 'cbtestsecuritygroupB-{0}'.format(uuid.uuid4()).lower()
         net = self.provider.network.create(name=name)
         sg = self.provider.security.security_groups.create(
             name=name, description=name, network_id=net.id)
@@ -224,7 +224,7 @@ class CloudSecurityServiceTestCase(ProviderTestBase):
 
     def test_security_group_group_rule(self):
         """Test for proper creation of a security group rule."""
-        name = 'cbtestsecuritygroup-c'
+        name = 'cbtestsecuritygroupC-{0}'.format(uuid.uuid4()).lower()
         net = self.provider.network.create(name=name)
         sg = self.provider.security.security_groups.create(
             name=name, description=name, network_id=net.id)


### PR DESCRIPTION
Instead of passing the network name, we now pass the network object
to the security group so that it has access to network name and
network id.

Also, there is a bug in the GCE API that in some cases, when the
network id has more than 19 digits, we cannot filter by id. As a
workaround, we list all networks and filter locally.

@baizhang @mbookman @nuwang @afgane