### PR TITLE
Version Conflict when trying to run tox tests #37

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ with open(os.path.join('cloudbridge', '__init__.py')) as f:
             break
 
 base_reqs = ['bunch>=1.0.1', 'six>=1.10.0', 'retrying>=1.3.3']
-openstack_reqs = ['python-novaclient==7.0.0',
+openstack_reqs = ['requests<2.13.0',
+                  'Babel>=2.3.4,<2.4.0',
+                  'python-novaclient==7.0.0',
                   'python-glanceclient>=2.5.0,<=2.6.0',
                   'python-cinderclient>=1.9.0,<=2.0.1',
                   'python-swiftclient>=3.2.0,<=3.3.0',


### PR DESCRIPTION
If you clone the repository, setup the needed environment and then run
tox, it fails with a version conflict error.

This happens because the dependencies in setup.py are best resolved by
dropping down to and installing requests 2.12.5. However, that version
of requests in turn explicitly states that it requires Babel==2.3.4 and
not the version Babel==2.4.0 that has already been installed.

Instant end of run :(

This commit makes the version of Babel explicit