### PR TITLE
The tests expect block storage to be available in all zones #39

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -132,12 +132,13 @@ def create_test_instance(
 
 
 def get_test_instance(provider, name, key_pair=None, security_groups=None,
-                      subnet=None):
+                      subnet=None, zone=None):
     launch_config = None
     instance = create_test_instance(
         provider,
         name,
         subnet=subnet,
+        zone=zone,
         key_pair=key_pair,
         security_groups=security_groups,
         launch_config=launch_config)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -118,27 +118,26 @@ def delete_test_network(network):
 
 
 def create_test_instance(
-        provider, instance_name, subnet, zone=None, launch_config=None,
+        provider, instance_name, subnet, launch_config=None,
         key_pair=None, security_groups=None):
     return provider.compute.instances.create(
         instance_name,
         get_provider_test_data(provider, 'image'),
         get_provider_test_data(provider, 'instance_type'),
         subnet=subnet,
-        zone=zone,
+        zone=get_provider_test_data(provider, 'placement'),
         key_pair=key_pair,
         security_groups=security_groups,
         launch_config=launch_config)
 
 
 def get_test_instance(provider, name, key_pair=None, security_groups=None,
-                      subnet=None, zone=None):
+                      subnet=None):
     launch_config = None
     instance = create_test_instance(
         provider,
         name,
         subnet=subnet,
-        zone=zone,
         key_pair=key_pair,
         security_groups=security_groups,
         launch_config=launch_config)

--- a/test/test_block_store_service.py
+++ b/test/test_block_store_service.py
@@ -107,7 +107,9 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
             net, subnet = helpers.create_test_network(
                 self.provider, instance_name)
             test_instance = helpers.get_test_instance(
-                self.provider, instance_name, subnet=subnet)
+                self.provider, instance_name, subnet=subnet,
+                zone=helpers.get_provider_test_data(self.provider,
+                                                    'placement'))
             name = "CBUnitTestAttachVol-{0}".format(uuid.uuid4())
             test_vol = self.provider.block_store.volumes.create(
                 name, 1, test_instance.zone_id)
@@ -140,7 +142,9 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
             net, subnet = helpers.create_test_network(
                 self.provider, instance_name)
             test_instance = helpers.get_test_instance(
-                self.provider, instance_name, subnet=subnet)
+                self.provider, instance_name, subnet=subnet,
+                zone=helpers.get_provider_test_data(self.provider,
+                                                    'placement'))
 
             name = "CBUnitTestVolProps-{0}".format(uuid.uuid4())
             test_vol = self.provider.block_store.volumes.create(

--- a/test/test_block_store_service.py
+++ b/test/test_block_store_service.py
@@ -107,9 +107,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
             net, subnet = helpers.create_test_network(
                 self.provider, instance_name)
             test_instance = helpers.get_test_instance(
-                self.provider, instance_name, subnet=subnet,
-                zone=helpers.get_provider_test_data(self.provider,
-                                                    'placement'))
+                self.provider, instance_name, subnet=subnet)
             name = "CBUnitTestAttachVol-{0}".format(uuid.uuid4())
             test_vol = self.provider.block_store.volumes.create(
                 name, 1, test_instance.zone_id)
@@ -142,9 +140,7 @@ class CloudBlockStoreServiceTestCase(ProviderTestBase):
             net, subnet = helpers.create_test_network(
                 self.provider, instance_name)
             test_instance = helpers.get_test_instance(
-                self.provider, instance_name, subnet=subnet,
-                zone=helpers.get_provider_test_data(self.provider,
-                                                    'placement'))
+                self.provider, instance_name, subnet=subnet)
 
             name = "CBUnitTestVolProps-{0}".format(uuid.uuid4())
             test_vol = self.provider.block_store.volumes.create(

--- a/test/test_compute_service.py
+++ b/test/test_compute_service.py
@@ -319,8 +319,6 @@ class CloudComputeServiceTestCase(ProviderTestBase):
                         self.provider,
                         name,
                         subnet=subnet,
-                        zone=helpers.get_provider_test_data(self.provider,
-                                                            'placement'),
                         launch_config=lc)
 
                     with helpers.cleanup_action(lambda:


### PR DESCRIPTION
As written, the tests for the block store service expect block storage
to be available in the same default zone as the instance created.

On our nectar cloud this is not necessarily true: block storage for a
given project may only be available in one of the zones. Hence the tests
attempt to create block storage in the same default zone as the instance
will most often fail.

This commit allows the zone a test instance is to be run in to be set:
and changes two of the block store tests to use the
helpers.get_provider_test_data(self.provider, 'placement') setting. In
this way the instance can be made to run in the same zone that block
storage is available in.