### PR TITLE
Upload delete of files larger than 5 Gig to Swift #35

### DIFF
--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -244,10 +244,12 @@ class OpenStackCloudProvider(BaseCloudProvider):
         Returns a **copy** of the source options with all keys that are not in
         the ``method_to_match`` parameter list removed.
 
-        .. note:: If ``options`` has the ``os_options`` key set it will have
-            any values the value dictionary removed in they copy if they are
-            not set, as they have higher precedence that our settings and thus
-            effectively mask our settings.
+        .. note:: If ``options`` has the ``os_options`` key it will have
+            both the key and its value removed. This is because any entries
+            in this dictionary value will override our settings. This
+            situation is only going to happen when the `_connect_swift`
+            method is called by the SwiftService to manufacture new
+            connections.
 
         .. seealso::
             https://docs.openstack.org/developer/python-swiftclient/swiftclient.html#module-swiftclient.client
@@ -271,9 +273,7 @@ class OpenStackCloudProvider(BaseCloudProvider):
             result = {key: val for key, val in options.items() if
                       key in parameters}
             # Don't allow the options to override our authentication
-            if 'os_options' in result:
-                result['os_options'] = {key: val for key, val in
-                                        result['os_options'].items() if val}
+            result.pop('os_options', None)
         return result
 
     def _connect_swift(self, options=None):

--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -1,5 +1,7 @@
 """Provider implementation based on OpenStack Python clients for OpenStack."""
 
+import inspect
+
 import os
 
 from cinderclient import client as cinder_client
@@ -236,19 +238,58 @@ class OpenStackCloudProvider(BaseCloudProvider):
 #         return glance_client.Client(version=api_version,
 #                                     session=self.keystone.session)
 
-    def _connect_swift(self):
+    @staticmethod
+    def _clean_options(options, method_to_match):
+        """
+        Returns a copy of the source options with all keys that are not in the
+        ``method_to_match`` parameter list removed.
+
+        :param options: The source options.
+        :type options: ``dict``
+        :param method_to_match: The method whose signature is to be matched
+        :type method_to_match: A callable
+        :return: A copy of the source options with all keys that are not in the
+            ``method_to_match`` parameter list removed. If options is ``None``
+            then this will be an empty dictionary
+        :rtype: ``dict``
+        """
+        result = dict(options or {})
+        if len(result):
+            # Don't allow the options to override our authentication
+            result['os_options'] = None
+            passed_in_options = set(result.keys())
+            try:
+                method_signature = inspect.signature(method_to_match)
+                parameters = set(method_signature.parameters.keys())
+            except AttributeError:
+                parameters = set(inspect.getargspec(method_to_match)[0])
+            difference = passed_in_options - parameters
+            for name in difference:
+                del result[name]
+        return result
+
+    def _connect_swift(self, options=None):
+        """
+        Get an OpenStack Swift (object store) client connection.
+
+        :param options: A dictionary of options from which values will be
+            passed to the connection.
+        :return: A Swift client connection using the auth credentials held by
+            the OpenStackCloudProvider instance
+        """
+        clean_options = self._clean_options(options,
+                                            swift_client.Connection.__init__)
         storage_url = self._get_config_value(
             'os_storage_url', os.environ.get('OS_STORAGE_URL', None))
         auth_token = self._get_config_value(
             'os_auth_token', os.environ.get('OS_AUTH_TOKEN', None))
-
-        """Get an OpenStack Swift (object store) client object cloud."""
         if storage_url and auth_token:
-            return swift_client.Connection(preauthurl=storage_url,
-                                           preauthtoken=auth_token)
+            clean_options['preauthurl'] = storage_url
+            clean_options['preauthtoken'] = auth_token
         else:
-            return swift_client.Connection(authurl=self.auth_url,
-                                           session=self._keystone_session)
+            clean_options['authurl'] = self.auth_url
+            clean_options['session'] = self._keystone_session
+        return swift_client.Connection(**clean_options)
 
     def _connect_neutron(self):
         """Get an OpenStack Neutron (networking) client object cloud."""

--- a/test/test_object_store_service.py
+++ b/test/test_object_store_service.py
@@ -1,4 +1,6 @@
+import filecmp
 import os
+import tempfile
 import uuid
 
 from datetime import datetime
@@ -207,3 +209,33 @@ class CloudObjectStoreServiceTestCase(ProviderTestBase):
                 obj.save_content(target_stream)
                 with open(test_file, 'rb') as f:
                     self.assertEqual(target_stream.getvalue(), f.read())
+
+    @skip("Skip unless you want to test swift objects bigger than 5 Gig")
+    @helpers.skipIfNoService(['object_store'])
+    def test_upload_download_bucket_content_with_large_file(self):
+        """
+        Creates a 6 Gig file in the temp directory, then uploads it to
+        Swift. Once uploaded, then downloads to a new file in the temp
+        directory and compares the two files to see if they match.
+        """
+        temp_dir = tempfile.gettempdir()
+        file_name = '6GigTest.tmp'
+        six_gig_file = os.path.join(temp_dir, file_name)
+        with open(six_gig_file, "wb") as out:
+            out.truncate(6 * 1024 * 1024 * 1024)  # 6 Gig...
+        with helpers.cleanup_action(lambda: os.remove(six_gig_file)):
+            download_file = "{0}/cbtestfile-{1}".format(temp_dir, file_name)
+            bucket_name = "cbtestbucketlargeobjs-{0}".format(uuid.uuid4())
+            test_bucket = self.provider.object_store.create(bucket_name)
+            with helpers.cleanup_action(lambda: test_bucket.delete()):
+                test_obj = test_bucket.create_object(file_name)
+                with helpers.cleanup_action(lambda: test_obj.delete()):
+                    file_uploaded = test_obj.upload_from_file(six_gig_file)
+                    self.assertTrue(file_uploaded, "Could not upload object?")
+                    with helpers.cleanup_action(
+                            lambda: os.remove(download_file)):
+                        with open(download_file, 'wb') as f:
+                            test_obj.save_content(f)
+                            self.assertTrue(
+                                filecmp.cmp(six_gig_file, download_file),
+                                "Uploaded file != downloaded")


### PR DESCRIPTION
As coded, the low level Swift Connection is used to upload and delete
files. However, this class does not handle the upload and deletion of
files over 5 Gig in size that need to be segmented.

This commit replaces the use of the Swift Connection class with the
SwiftService class in these two cases. Files that are larger than
5 Gig will now be broken into segments on the 5 Gig boundary, and the
delete call will be able to delete the segmented files.