### PR TITLE
OpenStackFloatingIP in_use method doesn't return the correct result #42

### DIFF
--- a/cloudbridge/cloud/providers/openstack/resources.py
+++ b/cloudbridge/cloud/providers/openstack/resources.py
@@ -788,7 +788,7 @@ class OpenStackFloatingIP(BaseFloatingIP):
         return self._ip.get('fixed_ip_address', None)
 
     def in_use(self):
-        return True if self._ip.get('status', None) == 'ACTIVE' else False
+        return bool(self._ip.get('port_id', None))
 
     def delete(self):
         self._provider.neutron.delete_floatingip(self.id)


### PR DESCRIPTION
The floating IP status was tests, and if found to be 'ACTIVE' True was
returned. However, on our nectar cloud a newly created floating IP is
set to 'ACTIVE' by default - even though it is not in use.

This commit uses port id as indicator of being in use: if set, then
the floating ip is attached, if not, it is not.