### PR TITLE
Fixes for GCE provider issues

### DIFF
--- a/cloudbridge/cloud/providers/aws/provider.py
+++ b/cloudbridge/cloud/providers/aws/provider.py
@@ -31,7 +31,6 @@ class AWSCloudProvider(BaseCloudProvider):
 
     def __init__(self, config):
         super(AWSCloudProvider, self).__init__(config)
-        self.cloud_type = 'aws'
 
         # Initialize cloud connection fields
         self.a_key = self._get_config_value(

--- a/cloudbridge/cloud/providers/gce/provider.py
+++ b/cloudbridge/cloud/providers/gce/provider.py
@@ -136,6 +136,7 @@ class GCECloudProvider(BaseCloudProvider):
 
     def __init__(self, config):
         super(GCECloudProvider, self).__init__(config)
+        self.cloud_type = 'gce'
 
         # Initialize cloud connection fields
         self.client_email = self._get_config_value(

--- a/cloudbridge/cloud/providers/gce/provider.py
+++ b/cloudbridge/cloud/providers/gce/provider.py
@@ -136,7 +136,6 @@ class GCECloudProvider(BaseCloudProvider):
 
     def __init__(self, config):
         super(GCECloudProvider, self).__init__(config)
-        self.cloud_type = 'gce'
 
         # Initialize cloud connection fields
         self.client_email = self._get_config_value(

--- a/cloudbridge/cloud/providers/gce/resources.py
+++ b/cloudbridge/cloud/providers/gce/resources.py
@@ -655,7 +655,7 @@ class GCEMachineImage(BaseMachineImage):
         :rtype: ``str``
         :return: ID for this instance as returned by the cloud middleware.
         """
-        return self._gce_image.get('selfLink')
+        return self._gce_image['name']
 
     @property
     def name(self):

--- a/cloudbridge/cloud/providers/gce/services.py
+++ b/cloudbridge/cloud/providers/gce/services.py
@@ -377,7 +377,7 @@ class GCEImageService(BaseImageService):
             for project in GCEImageService._PUBLIC_IMAGE_PROJECTS:
                 for image in helpers.iter_all(
                         self.provider.gce_compute.images(), project=project):
-                    self._public_iamges.append(
+                    self._public_images.append(
                         GCEMachineImage(self.provider, image))
         except googleapiclient.errors.HttpError as http_error:
                 cb.log.warning("googleapiclient.errors.HttpError: {0}".format(
@@ -548,8 +548,10 @@ class GCEInstanceService(BaseInstanceService):
                               maxResults=max_result,
                               pageToken=marker)
                         .execute())
-        instances = [GCEInstance(self.provider, inst)
-                     for inst in response['items']]
+        instances = []
+        if 'items' in response:
+            instances = [GCEInstance(self.provider, inst)
+                         for inst in response['items']]
         if len(instances) > max_result:
             cb.log.warning('Expected at most %d results; got %d',
                            max_result, len(instances))

--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -33,7 +33,6 @@ class OpenStackCloudProvider(BaseCloudProvider):
 
     def __init__(self, config):
         super(OpenStackCloudProvider, self).__init__(config)
-        self.cloud_type = 'openstack'
 
         # Initialize cloud connection fields
         self.username = self._get_config_value(


### PR DESCRIPTION
This pull request fixes some issues that I ran into when testing the GCE integration with the Django cloudlaunch backend:
* cloudlaunch expects that CloudProviders have a `cloud_type` property so I added that
  * perhaps cloud_type should explicitly be added to the interface?
* cloudlaunch REST hyperlink building didn't like putting the selfLink as the image id in the reversed URL.  Looking at the API GCE actually uses the image name as the identifier so I changed GCEMachineImage.id to return the GCE image name.  Besides now working this seems more consistent with how cloudbridge/cloudlaunch expect to use a GCEMachineImage.id.
* in services.py there was one type and then one spot in the code where it assumed that 'items' would be in the response but that's not the case if there are no instances.