### PR TITLE
Removing cloud_type attribute: use PROVIDER_ID instead

### DIFF
--- a/cloudbridge/cloud/providers/aws/provider.py
+++ b/cloudbridge/cloud/providers/aws/provider.py
@@ -31,7 +31,6 @@ class AWSCloudProvider(BaseCloudProvider):
 
     def __init__(self, config):
         super(AWSCloudProvider, self).__init__(config)
-        self.cloud_type = 'aws'
 
         # Initialize cloud connection fields
         self.a_key = self._get_config_value(

--- a/cloudbridge/cloud/providers/openstack/provider.py
+++ b/cloudbridge/cloud/providers/openstack/provider.py
@@ -33,7 +33,6 @@ class OpenStackCloudProvider(BaseCloudProvider):
 
     def __init__(self, config):
         super(OpenStackCloudProvider, self).__init__(config)
-        self.cloud_type = 'openstack'
 
         # Initialize cloud connection fields
         self.username = self._get_config_value(


### PR DESCRIPTION
This commit was originally submitted in #52 along with some other commits that are no longer wanted. So this pull request just splits it out into its own PR.

See also [Nuwan's comment on PR #52](https://github.com/gvlproject/cloudbridge/pull/52#issuecomment-319359191) for motivation for this change.

Also note that cloudlaunch has already been updated to remove references to provider cloud_type.