### PR TITLE
Conditional builds and coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,29 +22,54 @@ matrix:
       env: TOX_ENV=pypy-openstack
 before_install:
     - |
-      DOCS_REGEX='(\.rst$)|(^(docs))/'
-      FILES_IN_CHANGESET="`git diff --name-only $TRAVIS_COMMIT_RANGE`"
-      echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX" || {
-         echo "Only docs were updated. Stopping build process."
-         exit
-      }
-      # Extract env and provider from $TOXENV into $PYENV and $PROVIDER respectively
-      IFS=- read PYENV PROVIDER <<< "$TOXENV"
-      echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX|(^(cloudbridge/cloud/providers))" || {
-          echo "Only docs and providers were updated. Checking whether this provider was changed."
-          echo "$FILES_IN_CHANGESET" | grep -qE "^(cloudbridge/cloud/providers/$PROVIDER)" && {
-              echo "This provider was affected by this changeset. Running tests."
-          } || {
-              echo "This provider was not affected by this changeset. Stopping build process."
+      case "$TRAVIS_EVENT_TYPE" in
+        push|pull_request)
+           # Check whether we need to run a test for this provider
+           DOCS_REGEX='(\.rst$)|(^(docs))/'
+           FILES_IN_CHANGESET="`git diff --name-only $TRAVIS_COMMIT_RANGE`"
+           echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX" || {
+              echo "Only docs were updated. Stopping build process."
               exit
-          }
-      }
+           }
+           echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX|(^(cloudbridge/cloud/providers))" || {
+              echo "Only docs and providers were updated. Checking whether this provider was changed."
+              # Extract env and provider from $TOXENV into $PYENV and $PROVIDER respectively
+              IFS=- read PYENV PROVIDER <<< "$TOX_ENV"
+              echo "$FILES_IN_CHANGESET" | grep -qE "^(cloudbridge/cloud/providers/$PROVIDER)" && {
+                 echo "This provider was affected by this changeset. Running tests."
+              } || {
+                 echo "This provider was not affected by this changeset. Stopping build process."
+                 exit
+              }
+           }
+           ;;
+        *)
+           echo "Build triggered through API or CRON job. Running regardless of changes"
+           ;;
+      esac
 install:
-  - pip install tox
-  - pip install coveralls
-  - pip install codecov
+    - pip install tox
+    - pip install coveralls
+    - pip install codecov
 script:
-  - tox -e $TOX_ENV
+    - tox -e $TOX_ENV
 after_success:
-  - coveralls
-  - codecov
+    - |
+      case "$TRAVIS_EVENT_TYPE" in
+        push|pull_request)
+           # Don't run coverage if tests or cloudbridge interface was not affected
+           DOCS_REGEX='(\.rst$)|(^(docs))/'
+           FILES_IN_CHANGESET="`git diff --name-only $TRAVIS_COMMIT_RANGE`"
+           echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX|(^(cloudbridge/cloud/providers))" && {
+              coveralls &
+              codecov &
+              wait
+           } || {
+              echo "Only docs and providers were updated. Not running coverage."
+           }
+           ;;
+        *)
+           echo "Build triggered through API or CRON job. Running regardless of changes"
+           ;;
+      esac
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 dist: trusty
 language: python
-python:
-  - 3.6
 os:
   - linux
 #  - osx
@@ -22,6 +20,25 @@ matrix:
       env: TOX_ENV=pypy-aws
     - python: pypy-5.3.1
       env: TOX_ENV=pypy-openstack
+before_install:
+    - |
+      DOCS_REGEX='(\.rst$)|(^(docs))/'
+      FILES_IN_CHANGESET="`git diff --name-only $TRAVIS_COMMIT_RANGE`"
+      echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX" || {
+         echo "Only docs were updated. Stopping build process."
+         exit
+      }
+      # Extract env and provider from $TOXENV into $PYENV and $PROVIDER respectively
+      IFS=- read PYENV PROVIDER <<< "$TOXENV"
+      echo "$FILES_IN_CHANGESET" | grep -qvE "$DOCS_REGEX|(^(cloudbridge/cloud/providers))" || {
+          echo "Only docs and providers were updated. Checking whether this provider was changed."
+          echo "$FILES_IN_CHANGESET" | grep -qE "^(cloudbridge/cloud/providers/$PROVIDER)" && {
+              echo "This provider was affected by this changeset. Running tests."
+          } || {
+              echo "This provider was not affected by this changeset. Stopping build process."
+              exit
+          }
+      }
 install:
   - pip install tox
   - pip install coveralls


### PR DESCRIPTION
This PR adds support for conditional builds and coverage reports. This way, if a push or pull request affects only a specific set of providers, only those providers' builds will be run. Also, builds are skipped altogether if only documentation has changed. Any changes that occur outside of the providers folder or docs folder will trigger a full build however.  Cron jobs or API based build triggers will also result in a full build.

Coverage reports are skipped altogether if only providers have been changed. The assumption being that test coverage is affected only by interface or test level changes, and less affected by individual provider changes. (This is also needed because coverage will drop drastically when only one provider is tested)

The intent is to save time and costs associated with repeated builds.