### PR TITLE
Refactor firewalls

### DIFF
--- a/cloudbridge/cloud/base/resources.py
+++ b/cloudbridge/cloud/base/resources.py
@@ -733,10 +733,11 @@ class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
         return self._name
 
     def __repr__(self):
-        return ("<CBVMFirewallRule: id: {0}; direction: {1}; protocol: {2};"
-                " from: {3}; to: {4}; cidr: {5}, src_dest_fw: {6}>"
-                .format(self.id, self.direction, self.protocol, self.from_port,
-                        self.to_port, self.cidr, self.src_dest_fw_id))
+        return ("<{0}: id: {1}; direction: {2}; protocol: {3};  from: {4};"
+                " to: {5}; cidr: {6}, src_dest_fw: {7}>"
+                .format(self.__class__.__name__, self.id, self.direction,
+                        self.protocol, self.from_port, self.to_port, self.cidr,
+                        self.src_dest_fw_id))
 
     def __eq__(self, other):
         return (isinstance(other, VMFirewallRule) and

--- a/cloudbridge/cloud/base/resources.py
+++ b/cloudbridge/cloud/base/resources.py
@@ -627,7 +627,6 @@ class BaseVMFirewall(BaseCloudResource, VMFirewall):
         return (isinstance(other, VMFirewall) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
-                len(self.rules) == len(other.rules) and  # Shortcut
                 set(self.rules) == set(other.rules))
 
     def __ne__(self, other):
@@ -668,29 +667,85 @@ class BaseVMFirewall(BaseCloudResource, VMFirewall):
                                             self.id, self.name)
 
 
+class BaseVMFirewallRuleContainer(BasePageableObjectMixin):
+
+    def __init__(self, provider, firewall):
+        self.__provider = provider
+        self.firewall = firewall
+
+    @property
+    def _provider(self):
+        return self.__provider
+
+    def get(self, rule_id):
+        matches = [rule for rule in self if rule.id == rule_id]
+        if matches:
+            return matches[0]
+        else:
+            return None
+
+    def find(self, **kwargs):
+        matches = self
+
+        def filter_by(prop_name, rules):
+            prop_val = kwargs.pop(prop_name, None)
+            if prop_val:
+                match = [r for r in rules if getattr(r, prop_name) == prop_val]
+                return match
+            return rules
+
+        matches = filter_by('name', matches)
+        matches = filter_by('direction', matches)
+        matches = filter_by('protocol', matches)
+        matches = filter_by('from_port', matches)
+        matches = filter_by('to_port', matches)
+        matches = filter_by('cidr', matches)
+        matches = filter_by('src_dest_fw', matches)
+        matches = filter_by('src_dest_fw_id', matches)
+        limit = kwargs.pop('limit', None)
+        marker = kwargs.pop('marker', None)
+
+        return ClientPagedResultList(self._provider, matches,
+                                     limit=limit, marker=marker)
+
+    def delete(self, rule_id):
+        rule = self.get(rule_id)
+        if rule:
+            rule.delete()
+
+
 class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
 
-    def __init__(self, provider, rule, parent):
-        super(BaseVMFirewallRule, self).__init__(provider)
+    def __init__(self, parent_fw, rule):
+        # pylint:disable=protected-access
+        super(BaseVMFirewallRule, self).__init__(
+            parent_fw._provider)
+        self.firewall = parent_fw
         self._rule = rule
-        self.parent = parent
 
+        # Cache name
+        self._name = "{0}-{1}-{2}-{3}-{4}-{5}".format(
+            self.direction, self.protocol, self.from_port, self.to_port,
+            self.cidr, self.src_dest_fw_id).lower()
+
+    @property
     def name(self):
-        """
-        VM firewall rules don't support names, so pass
-        """
-        pass
+        return self._name
 
     def __repr__(self):
-        return ("<CBVMFirewallRule: IP: {0}; from: {1}; to: {2}; grp: {3}>"
-                .format(self.ip_protocol, self.from_port, self.to_port,
-                        self.group))
+        return ("<CBVMFirewallRule: id: {0}; direction: {1}; protocol: {2};"
+                " from: {3}; to: {4}; cidr: {5}, src_dest_fw: {6}>"
+                .format(self.id, self.direction, self.protocol, self.from_port,
+                        self.to_port, self.cidr, self.src_dest_fw_id))
 
     def __eq__(self, other):
-        return self.ip_protocol == other.ip_protocol and \
-            self.from_port == other.from_port and \
-            self.to_port == other.to_port and \
-            self.cidr_ip == other.cidr_ip
+        return (isinstance(other, VMFirewallRule) and
+                self.direction == other.direction and
+                self.protocol == other.protocol and
+                self.from_port == other.from_port and
+                self.to_port == other.to_port and
+                self.cidr == other.cidr and
+                self.src_dest_fw_id == other.src_dest_fw_id)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -699,12 +754,19 @@ class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
         """
         Return a hash-based interpretation of all of the object's field values.
 
-        This is requried for operations on hashed collections including
+        This is requeried for operations on hashed collections including
         ``set``, ``frozenset``, and ``dict``.
         """
-        return hash("{0}{1}{2}{3}{4}".format(self.ip_protocol, self.from_port,
-                                             self.to_port, self.cidr_ip,
-                                             self.group))
+        return hash("{0}{1}{2}{3}{4}{5}".format(
+            self.direction, self.protocol, self.from_port, self.to_port,
+            self.cidr, self.src_dest_fw_id))
+
+    def to_json(self):
+        attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
+        js = {k: v for (k, v) in attr if not k.startswith('_')}
+        js['src_dest_fw'] = self.src_dest_fw_id
+        js['firewall'] = self.firewall.id
+        return js
 
 
 class BasePlacementZone(BaseCloudResource, PlacementZone):

--- a/cloudbridge/cloud/base/resources.py
+++ b/cloudbridge/cloud/base/resources.py
@@ -34,12 +34,12 @@ from cloudbridge.cloud.interfaces.resources import PlacementZone
 from cloudbridge.cloud.interfaces.resources import Region
 from cloudbridge.cloud.interfaces.resources import ResultList
 from cloudbridge.cloud.interfaces.resources import Router
-from cloudbridge.cloud.interfaces.resources import SecurityGroup
-from cloudbridge.cloud.interfaces.resources import SecurityGroupRule
 from cloudbridge.cloud.interfaces.resources import Snapshot
 from cloudbridge.cloud.interfaces.resources import SnapshotState
 from cloudbridge.cloud.interfaces.resources import Subnet
 from cloudbridge.cloud.interfaces.resources import SubnetState
+from cloudbridge.cloud.interfaces.resources import VMFirewall
+from cloudbridge.cloud.interfaces.resources import VMFirewallRule
 from cloudbridge.cloud.interfaces.resources import VMType
 from cloudbridge.cloud.interfaces.resources import Volume
 from cloudbridge.cloud.interfaces.resources import VolumeState
@@ -395,7 +395,7 @@ class BaseInstance(BaseCloudResource, BaseObjectLifeCycleMixin, Instance):
                 # check from most to least likely mutables
                 self.state == other.state and
                 self.name == other.name and
-                self.security_groups == other.security_groups and
+                self.vm_firewalls == other.vm_firewalls and
                 self.public_ips == other.public_ips and
                 self.private_ips == other.private_ips and
                 self.image_id == other.image_id)
@@ -614,17 +614,17 @@ class BaseKeyPair(BaseCloudResource, KeyPair):
         return "<CBKeyPair: {0}>".format(self.name)
 
 
-class BaseSecurityGroup(BaseCloudResource, SecurityGroup):
+class BaseVMFirewall(BaseCloudResource, VMFirewall):
 
-    def __init__(self, provider, security_group):
-        super(BaseSecurityGroup, self).__init__(provider)
-        self._security_group = security_group
+    def __init__(self, provider, vm_firewall):
+        super(BaseVMFirewall, self).__init__(provider)
+        self._vm_firewall = vm_firewall
 
     def __eq__(self, other):
         """
-        Check if all the defined rules match across both security groups.
+        Check if all the defined rules match across both VM firewalls.
         """
-        return (isinstance(other, SecurityGroup) and
+        return (isinstance(other, VMFirewall) and
                 # pylint:disable=protected-access
                 self._provider == other._provider and
                 len(self.rules) == len(other.rules) and  # Shortcut
@@ -636,53 +636,53 @@ class BaseSecurityGroup(BaseCloudResource, SecurityGroup):
     @property
     def id(self):
         """
-        Get the ID of this security group.
+        Get the ID of this VM firewall.
 
         :rtype: str
-        :return: Security group ID
+        :return: VM firewall ID
         """
-        return self._security_group.id
+        return self._vm_firewall.id
 
     @property
     def name(self):
         """
-        Return the name of this security group.
+        Return the name of this VM firewall.
         """
-        return self._security_group.name
+        return self._vm_firewall.name
 
     @property
     def description(self):
         """
-        Return the description of this security group.
+        Return the description of this VM firewall.
         """
-        return self._security_group.description
+        return self._vm_firewall.description
 
     def delete(self):
         """
-        Delete this security group.
+        Delete this VM firewall.
         """
-        return self._security_group.delete()
+        return self._vm_firewall.delete()
 
     def __repr__(self):
         return "<CB-{0}: {1} ({2})>".format(self.__class__.__name__,
                                             self.id, self.name)
 
 
-class BaseSecurityGroupRule(BaseCloudResource, SecurityGroupRule):
+class BaseVMFirewallRule(BaseCloudResource, VMFirewallRule):
 
     def __init__(self, provider, rule, parent):
-        super(BaseSecurityGroupRule, self).__init__(provider)
+        super(BaseVMFirewallRule, self).__init__(provider)
         self._rule = rule
         self.parent = parent
 
     def name(self):
         """
-        Security group rules don't support names, so pass
+        VM firewall rules don't support names, so pass
         """
         pass
 
     def __repr__(self):
-        return ("<CBSecurityGroupRule: IP: {0}; from: {1}; to: {2}; grp: {3}>"
+        return ("<CBVMFirewallRule: IP: {0}; from: {1}; to: {2}; grp: {3}>"
                 .format(self.ip_protocol, self.from_port, self.to_port,
                         self.group))
 
@@ -891,7 +891,7 @@ class BaseFloatingIP(BaseCloudResource, FloatingIP):
 
     def name(self):
         """
-        Security group rules don't support names, so pass
+        VM firewall rules don't support names, so pass
         """
         pass
 

--- a/cloudbridge/cloud/base/services.py
+++ b/cloudbridge/cloud/base/services.py
@@ -15,10 +15,10 @@ from cloudbridge.cloud.interfaces.services import NetworkingService
 from cloudbridge.cloud.interfaces.services import ObjectStoreService
 from cloudbridge.cloud.interfaces.services import RegionService
 from cloudbridge.cloud.interfaces.services import RouterService
-from cloudbridge.cloud.interfaces.services import SecurityGroupService
 from cloudbridge.cloud.interfaces.services import SecurityService
 from cloudbridge.cloud.interfaces.services import SnapshotService
 from cloudbridge.cloud.interfaces.services import SubnetService
+from cloudbridge.cloud.interfaces.services import VMFirewallService
 from cloudbridge.cloud.interfaces.services import VMTypeService
 from cloudbridge.cloud.interfaces.services import VolumeService
 
@@ -105,11 +105,11 @@ class BaseKeyPairService(
         return True
 
 
-class BaseSecurityGroupService(
-        BasePageableObjectMixin, SecurityGroupService, BaseCloudService):
+class BaseVMFirewallService(
+        BasePageableObjectMixin, VMFirewallService, BaseCloudService):
 
     def __init__(self, provider):
-        super(BaseSecurityGroupService, self).__init__(provider)
+        super(BaseVMFirewallService, self).__init__(provider)
 
 
 class BaseVMTypeService(

--- a/cloudbridge/cloud/interfaces/exceptions.py
+++ b/cloudbridge/cloud/interfaces/exceptions.py
@@ -31,7 +31,7 @@ class InvalidConfigurationException(CloudBridgeBaseException):
 class ProviderConnectionException(CloudBridgeBaseException):
     """
     Marker interface for connection errors to a cloud provider.
-    Thrown when cloudbridge is unable to connect with a provider,
+    Thrown when CloudBridge is unable to connect with a provider,
     for example, when credentials are incorrect, or connection
     settings are invalid.
     """
@@ -41,8 +41,21 @@ class ProviderConnectionException(CloudBridgeBaseException):
 class InvalidNameException(CloudBridgeBaseException):
     """
     Marker interface for any attempt to set an invalid name on
-    a cloudbridge resource.An example would be setting uppercase
+    a CloudBridge resource.An example would be setting uppercase
     letters, which are not allowed in a resource name.
     """
     def __init__(self, msg):
         super(InvalidNameException, self).__init__(msg)
+
+
+class InvalidValueException(CloudBridgeBaseException):
+    """
+    Marker interface for any attempt to set an invalid value on a CloudBridge
+    resource.An example would be setting an unrecognised value for the
+    direction of a firewall rule other than TrafficDirection.INBOUND or
+    TrafficDirection.OUTBOUND.
+    """
+    def __init__(self, param, value):
+        super(InvalidNameException, self).__init__(
+            "Param %s has been given an unrecognised value %s" %
+            (param, value))

--- a/cloudbridge/cloud/interfaces/provider.py
+++ b/cloudbridge/cloud/interfaces/provider.py
@@ -163,7 +163,7 @@ class CloudProvider(object):
         .. code-block:: python
 
             keypairs = provider.security.keypairs.list()
-            security_groups = provider.security.security_groups.list()
+            vm_firewalls = provider.security.vm_firewalls.list()
 
 
         :rtype: ``object`` of :class:`.SecurityService`

--- a/cloudbridge/cloud/interfaces/resources.py
+++ b/cloudbridge/cloud/interfaces/resources.py
@@ -539,22 +539,22 @@ class Instance(ObjectLifeCycleMixin, CloudResource):
 #         pass
 
     @abstractproperty
-    def security_groups(self):
+    def vm_firewalls(self):
         """
-        Get the security groups associated with this instance.
+        Get the firewalls (security groups) associated with this instance.
 
-        :rtype: list or :class:`.SecurityGroup` objects
-        :return: A list of SecurityGroup objects associated with this instance.
+        :rtype: list or :class:`.VMFirewall` objects
+        :return: A list of VMFirewall objects associated with this instance.
         """
         pass
 
     @abstractproperty
-    def security_group_ids(self):
+    def vm_firewall_ids(self):
         """
-        Get the IDs of the security groups associated with this instance.
+        Get the IDs of the VM firewalls associated with this instance.
 
         :rtype: list or :class:``str``
-        :return: A list of the SecurityGroup IDs associated with this instance.
+        :return: A list of the VMFirewall IDs associated with this instance.
         """
         pass
 
@@ -599,22 +599,22 @@ class Instance(ObjectLifeCycleMixin, CloudResource):
         pass
 
     @abstractmethod
-    def add_security_group(self, sg):
+    def add_vm_firewall(self, firewall):
         """
-        Add a security group to this instance
+        Add a VM firewall to this instance
 
-        :type sg: ``SecurityGroup``
-        :param sg: The SecurityGroup to associate with the instance.
+        :type firewall: ``VMFirewall``
+        :param firewall: The VMFirewall to associate with the instance.
         """
         pass
 
     @abstractmethod
-    def remove_security_group(self, sg):
+    def remove_vm_firewall(self, firewall):
         """
-        Remove a security group from this instance
+        Remove a VM firewall from this instance
 
-        :type sg: ``SecurityGroup``
-        :param sg: The SecurityGroup to associate with the instance.
+        :type firewall: ``VMFirewall``
+        :param firewall: The VMFirewall to associate with the instance.
         """
         pass
 
@@ -1672,24 +1672,24 @@ class VMType(CloudResource):
         pass
 
 
-class SecurityGroup(CloudResource):
+class VMFirewall(CloudResource):
 
     __metaclass__ = ABCMeta
 
     @abstractproperty
     def description(self):
         """
-        Return the description of this security group.
+        Return the description of this VM firewall.
 
         :rtype: ``str``
-        :return: A description of this security group.
+        :return: A description of this VM firewall.
         """
         pass
 
     @abstractproperty
     def network_id(self):
         """
-        Network ID with which this security group is associated.
+        Network ID with which this VM firewall is associated.
 
         :rtype: ``str``
         :return: Provider-supplied network ID or ``None`` is not available.
@@ -1699,17 +1699,17 @@ class SecurityGroup(CloudResource):
     @abstractproperty
     def rules(self):
         """
-        Get the list of rules for this security group.
+        Get the list of rules for this VM firewall.
 
-        :rtype: list of :class:`.SecurityGroupRule`
-        :return: A list of security group rule objects.
+        :rtype: list of :class:`.VMFirewallRule`
+        :return: A list of VM firewall rule objects.
         """
         pass
 
     @abstractmethod
     def delete(self):
         """
-        Delete this security group.
+        Delete this VM firewall.
 
         :rtype: ``bool``
         :return: ``True`` if successful.
@@ -1718,12 +1718,12 @@ class SecurityGroup(CloudResource):
 
     @abstractmethod
     def add_rule(self, ip_protocol=None, from_port=None, to_port=None,
-                 cidr_ip=None, src_group=None):
+                 cidr_ip=None, src_firewall=None):
         """
-        Create a security group rule. If the rule already exists, simply
+        Create a VM firewall rule. If the rule already exists, simply
         returns it.
 
-        You need to pass in either ``src_group`` OR ``ip_protocol`` AND
+        You need to pass in either ``src_firewall`` OR ``ip_protocol`` AND
         ``from_port``, ``to_port``, ``cidr_ip``. In other words, either
         you are authorizing another group or you are authorizing some
         ip-based rule.
@@ -1740,20 +1740,20 @@ class SecurityGroup(CloudResource):
         :type cidr_ip: ``str`` or list of ``str``
         :param cidr_ip: The CIDR block you are providing access to.
 
-        :type src_group: :class:`.SecurityGroup`
-        :param src_group: The Security Group object you are granting access to.
+        :type src_firewall: :class:`.VMFirewall`
+        :param src_firewall: The VM firewall object you are granting access to.
 
-        :rtype: :class:`.SecurityGroupRule`
+        :rtype: :class:`.VMFirewallRule`
         :return: Rule object if successful or ``None``.
         """
         pass
 
     def get_rule(self, ip_protocol=None, from_port=None, to_port=None,
-                 cidr_ip=None, src_group=None):
+                 cidr_ip=None, src_firewall=None):
         """
-        Get a security group rule with the specified parameters.
+        Get a VM firewall rule with the specified parameters.
 
-        You need to pass in either ``src_group`` OR ``ip_protocol`` AND
+        You need to pass in either ``src_firewall`` OR ``ip_protocol`` AND
         ``from_port``, ``to_port``, and ``cidr_ip``. Note that when retrieving
         a group rule, this method will return only one rule although possibly
         several rules exist for the group rule. In that case, use the
@@ -1771,19 +1771,19 @@ class SecurityGroup(CloudResource):
         :type cidr_ip: ``str`` or list of ``str``
         :param cidr_ip: The CIDR block you are providing access to.
 
-        :type src_group: :class:`.SecurityGroup`
-        :param src_group: The Security Group object you are granting access to.
+        :type src_firewall: :class:`.VMFirewall`
+        :param src_firewall: The VM firewall object you are granting access to.
 
-        :rtype: :class:`.SecurityGroupRule`
-        :return: Role object if one can be found or ``None``.
+        :rtype: :class:`.VMFirewallRule`
+        :return: Rule object if one can be found or ``None``.
         """
         pass
 
 
-class SecurityGroupRule(CloudResource):
+class VMFirewallRule(CloudResource):
 
     """
-    Represents a security group rule.
+    Represents a VM firewall rule.
     """
     __metaclass__ = ABCMeta
 
@@ -1820,7 +1820,7 @@ class SecurityGroupRule(CloudResource):
     @abstractproperty
     def cidr_ip(self):
         """
-        CIDR block this security group is providing access to.
+        CIDR block this VM firewall is providing access to.
 
         :rtype: ``str``
         :return: CIDR block.
@@ -1830,10 +1830,10 @@ class SecurityGroupRule(CloudResource):
     @abstractproperty
     def group(self):
         """
-        Security group given access permissions by this rule.
+        VM firewall given access permissions by this rule.
 
-        :rtype: :class:``.SecurityGroup``
-        :return: The Security Group with granting access.
+        :rtype: :class:``.VMFirewall``
+        :return: The VM firewall with granting access.
         """
         pass
 

--- a/cloudbridge/cloud/interfaces/services.py
+++ b/cloudbridge/cloud/interfaces/services.py
@@ -1181,12 +1181,6 @@ class VMFirewallService(PageableObjectMixin, CloudService):
 
         :type group_id: str
         :param group_id: The VM firewall ID to be deleted.
-
-        :rtype: ``bool``
-        :return:  ``True`` if the VM firewall does not exist, ``False``
-                  otherwise. Note that this implies that the group may not have
-                  been deleted by this method but instead has not existed in
-                  the first place.
         """
         pass
 

--- a/cloudbridge/cloud/interfaces/services.py
+++ b/cloudbridge/cloud/interfaces/services.py
@@ -206,7 +206,7 @@ class InstanceService(PageableObjectMixin, CloudService):
 
     @abstractmethod
     def create(self, name, image, vm_type, subnet, zone=None,
-               key_pair=None, security_groups=None, user_data=None,
+               key_pair=None, vm_firewalls=None, user_data=None,
                launch_config=None,
                **kwargs):
         """
@@ -246,16 +246,16 @@ class InstanceService(PageableObjectMixin, CloudService):
         :param key_pair: The KeyPair object or its name, to set for the
                          instance.
 
-        :type  security_groups: A ``list`` of ``SecurityGroup`` objects or a
-                                list of ``str`` object IDs
-        :param security_groups: A list of ``SecurityGroup`` objects or a list
-                                of ``SecurityGroup`` IDs, which should be
-                                assigned to this instance.
+        :type  vm_firewalls: A ``list`` of ``VMFirewall`` objects or a
+                             list of ``str`` object IDs
+        :param vm_firewalls: A list of ``VMFirewall`` objects or a list
+                             of ``VMFirewall`` IDs, which should be
+                             assigned to this instance.
 
-                                The security groups must be associated with the
-                                same network as the supplied subnet. Use
-                                ``network.security_groups`` to retrieve a list
-                                of security groups belonging to a network.
+                             The VM firewalls must be associated with the
+                             same network as the supplied subnet. Use
+                             ``network.vm_firewalls`` to retrieve a list
+                             of firewalls belonging to a network.
 
         :type  user_data: ``str``
         :param user_data: An extra userdata object which is compatible with
@@ -1008,24 +1008,24 @@ class SecurityService(CloudService):
         pass
 
     @abstractproperty
-    def security_groups(self):
+    def vm_firewalls(self):
         """
-        Provides access to security groups for this provider.
+        Provides access to firewalls (security groups) for this provider.
 
         Example:
 
         .. code-block:: python
 
-            # print all security groups
-            for sg in provider.security.security_groups:
-                print(sg.id, sg.name)
+            # print all VM firewalls
+            for fw in provider.security.vm_firewalls:
+                print(fw.id, fw.name)
 
-            # find security group by name
-            sg = provider.security.security_groups.find(name='my_sg')[0]
-            print(sg.id, sg.name)
+            # find firewall by name
+            fw = provider.security.vm_firewalls.find(name='my_vm_fw')[0]
+            print(fw.id, fw.name)
 
-        :rtype: :class:`.SecurityGroupService`
-        :return: a SecurityGroupService object
+        :rtype: :class:`.VMFirewallService`
+        :return: a VMFirewallService object
         """
         pass
 
@@ -1093,7 +1093,7 @@ class KeyPairService(PageableObjectMixin, CloudService):
     @abstractmethod
     def delete(self, key_pair_id):
         """
-        Delete an existing SecurityGroup.
+        Delete an existing VMFirewall.
 
         :type key_pair_id: str
         :param key_pair_id: The id of the key pair to be deleted.
@@ -1106,70 +1106,70 @@ class KeyPairService(PageableObjectMixin, CloudService):
         pass
 
 
-class SecurityGroupService(PageableObjectMixin, CloudService):
+class VMFirewallService(PageableObjectMixin, CloudService):
 
     """
-    Base interface for security groups.
+    Base interface for VM firewalls.
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get(self, security_group_id):
+    def get(self, vm_firewall_id):
         """
-        Returns a SecurityGroup given its ID. Returns ``None`` if the
-        SecurityGroup does not exist.
+        Returns a VMFirewall given its ID. Returns ``None`` if the
+        VMFirewall does not exist.
 
         Example:
 
         .. code-block:: python
 
-            sg = provider.security.security_groups.get('my_sg_id')
-            print(sg.id, sg.name)
+            fw = provider.security.vm_firewalls.get('my_fw_id')
+            print(fw.id, fw.name)
 
-        :rtype: :class:`.SecurityGroup`
-        :return:  a SecurityGroup instance
+        :rtype: :class:`.VMFirewall`
+        :return:  a VMFirewall instance
         """
         pass
 
     @abstractmethod
     def list(self, limit=None, marker=None):
         """
-        List all security groups associated with this account.
+        List all VM firewalls associated with this account.
 
-        :rtype: ``list`` of :class:`.SecurityGroup`
-        :return:  list of SecurityGroup objects
+        :rtype: ``list`` of :class:`.VMFirewall`
+        :return:  list of VMFirewall objects
         """
         pass
 
     @abstractmethod
     def create(self, name, description, network_id):
         """
-        Create a new SecurityGroup.
+        Create a new VMFirewall.
 
         :type name: str
-        :param name: The name of the new security group.
+        :param name: The name of the new VM firewall.
 
         :type description: str
-        :param description: The description of the new security group.
+        :param description: The description of the new VM firewall.
 
         :type  network_id: ``str``
-        :param network_id: Network ID under which to create the security group.
+        :param network_id: Network ID under which to create the VM firewall.
 
-        :rtype: ``object`` of :class:`.SecurityGroup`
-        :return:  A SecurityGroup instance or ``None`` if one was not created.
+        :rtype: ``object`` of :class:`.VMFirewall`
+        :return:  A VMFirewall instance or ``None`` if one was not created.
         """
         pass
 
     @abstractmethod
     def find(self, name, limit=None, marker=None):
         """
-        Get security groups associated with your account filtered by name.
+        Get VM firewalls associated with your account filtered by name.
 
         :type name: str
-        :param name: The name of the security group to retrieve.
+        :param name: The name of the VM firewall to retrieve.
 
-        :rtype: list of :class:`SecurityGroup`
-        :return: A list of SecurityGroup objects or an empty list if none
+        :rtype: list of :class:`VMFirewall`
+        :return: A list of VMFirewall objects or an empty list if none
                  found.
         """
         pass
@@ -1177,13 +1177,13 @@ class SecurityGroupService(PageableObjectMixin, CloudService):
     @abstractmethod
     def delete(self, group_id):
         """
-        Delete an existing SecurityGroup.
+        Delete an existing VMFirewall.
 
         :type group_id: str
-        :param group_id: The security group ID to be deleted.
+        :param group_id: The VM firewall ID to be deleted.
 
         :rtype: ``bool``
-        :return:  ``True`` if the security group does not exist, ``False``
+        :return:  ``True`` if the VM firewall does not exist, ``False``
                   otherwise. Note that this implies that the group may not have
                   been deleted by this method but instead has not existed in
                   the first place.

--- a/cloudbridge/cloud/providers/aws/resources.py
+++ b/cloudbridge/cloud/providers/aws/resources.py
@@ -23,9 +23,11 @@ from cloudbridge.cloud.base.resources import BaseSnapshot
 from cloudbridge.cloud.base.resources import BaseSubnet
 from cloudbridge.cloud.base.resources import BaseVMFirewall
 from cloudbridge.cloud.base.resources import BaseVMFirewallRule
+from cloudbridge.cloud.base.resources import BaseVMFirewallRuleContainer
 from cloudbridge.cloud.base.resources import BaseVMType
 from cloudbridge.cloud.base.resources import BaseVolume
 from cloudbridge.cloud.base.resources import ClientPagedResultList
+from cloudbridge.cloud.interfaces.exceptions import InvalidValueException
 from cloudbridge.cloud.interfaces.resources import GatewayState
 from cloudbridge.cloud.interfaces.resources import InstanceState
 from cloudbridge.cloud.interfaces.resources import MachineImageState
@@ -33,7 +35,7 @@ from cloudbridge.cloud.interfaces.resources import NetworkState
 from cloudbridge.cloud.interfaces.resources import RouterState
 from cloudbridge.cloud.interfaces.resources import SnapshotState
 from cloudbridge.cloud.interfaces.resources import SubnetState
-from cloudbridge.cloud.interfaces.resources import VMFirewall
+from cloudbridge.cloud.interfaces.resources import TrafficDirection
 from cloudbridge.cloud.interfaces.resources import VolumeState
 
 from .helpers import find_tag_value
@@ -548,6 +550,7 @@ class AWSVMFirewall(BaseVMFirewall):
 
     def __init__(self, provider, _vm_firewall):
         super(AWSVMFirewall, self).__init__(provider, _vm_firewall)
+        self._rule_container = AWSVMFirewallRuleContainer(provider, self)
 
     @property
     def name(self):
@@ -559,60 +562,10 @@ class AWSVMFirewall(BaseVMFirewall):
 
     @property
     def rules(self):
-        return [AWSVMFirewallRule(self._provider, r, self)
-                for r in self._vm_firewall.ip_permissions]
+        return self._rule_container
 
-    def add_rule(self, ip_protocol=None, from_port=None, to_port=None,
-                 cidr_ip=None, src_firewall=None):
-        try:
-            src_firewall_id = (
-                src_firewall.id if isinstance(src_firewall, VMFirewall)
-                else src_firewall)
-
-            ip_perm_entry = {
-                'IpProtocol': ip_protocol,
-                'FromPort': from_port,
-                'ToPort': to_port,
-                'IpRanges': [{'CidrIp': cidr_ip}] if cidr_ip else None,
-                'UserIdGroupPairs': [{
-                    'GroupId': src_firewall_id}
-                ] if src_firewall_id else None
-            }
-            # Filter out empty values to please Boto
-            ip_perms = [trim_empty_params(ip_perm_entry)]
-            self._vm_firewall.authorize_ingress(IpPermissions=ip_perms)
-            self._vm_firewall.reload()
-            return self.get_rule(ip_protocol, from_port, to_port, cidr_ip,
-                                 src_firewall_id)
-        except ClientError as ec2e:
-            if ec2e.response['Error']['Code'] == "InvalidPermission.Duplicate":
-                return self.get_rule(ip_protocol, from_port, to_port, cidr_ip,
-                                     src_firewall)
-            else:
-                raise ec2e
-
-    def get_rule(self, ip_protocol=None, from_port=None, to_port=None,
-                 cidr_ip=None, src_firewall=None):
-        src_firewall_id = (
-            src_firewall.id if isinstance(src_firewall, VMFirewall)
-            else src_firewall)
-        for rule in self._vm_firewall.ip_permissions:
-            if ip_protocol and rule['IpProtocol'] != ip_protocol:
-                continue
-            elif from_port and rule['FromPort'] != from_port:
-                continue
-            elif to_port and rule['ToPort'] != to_port:
-                continue
-            elif cidr_ip:
-                if cidr_ip not in [x['CidrIp'] for x in rule['IpRanges']]:
-                    continue
-            elif src_firewall_id:
-                if src_firewall_id not in [
-                    group_pair.get('GroupId') for group_pair in
-                        rule.get('UserIdGroupPairs', [])]:
-                    continue
-            return AWSVMFirewallRule(self._provider, rule, self)
-        return None
+    def refresh(self):
+        self._vm_firewall.reload()
 
     def to_json(self):
         attr = inspect.getmembers(self, lambda a: not inspect.isroutine(a))
@@ -624,77 +577,137 @@ class AWSVMFirewall(BaseVMFirewall):
         return js
 
 
+class AWSVMFirewallRuleContainer(BaseVMFirewallRuleContainer):
+
+    def __init__(self, provider, firewall):
+        super(AWSVMFirewallRuleContainer, self).__init__(provider, firewall)
+
+    def list(self, limit=None, marker=None):
+        # pylint:disable=protected-access
+        rules = [AWSVMFirewallRule(self.firewall,
+                                   TrafficDirection.INBOUND, r)
+                 for r in self.firewall._vm_firewall.ip_permissions]
+        rules = rules + [
+            AWSVMFirewallRule(
+                self.firewall, TrafficDirection.OUTBOUND, r)
+            for r in self.firewall._vm_firewall.ip_permissions_egress]
+        return ClientPagedResultList(self._provider, rules,
+                                     limit=limit, marker=marker)
+
+    def create(self,  direction, protocol=None, from_port=None,
+               to_port=None, cidr=None, src_dest_fw=None):
+        src_dest_fw_id = (
+            src_dest_fw.id if isinstance(src_dest_fw, AWSVMFirewall)
+            else src_dest_fw)
+
+        ip_perm_entry = AWSVMFirewallRule._construct_ip_perms(
+            protocol, from_port, to_port, cidr, src_dest_fw_id)
+        # Filter out empty values to please Boto
+        ip_perms = [trim_empty_params(ip_perm_entry)]
+
+        try:
+            if direction == TrafficDirection.INBOUND:
+                # pylint:disable=protected-access
+                self.firewall._vm_firewall.authorize_ingress(
+                    IpPermissions=ip_perms)
+            elif direction == TrafficDirection.OUTBOUND:
+                # pylint:disable=protected-access
+                self.firewall._vm_firewall.authorize_egress(
+                    IpPermissions=ip_perms)
+            else:
+                raise InvalidValueException("direction", direction)
+            self.firewall.refresh()
+            return AWSVMFirewallRule(self.firewall, direction, ip_perm_entry)
+        except ClientError as ec2e:
+            if ec2e.response['Error']['Code'] == "InvalidPermission.Duplicate":
+                return AWSVMFirewallRule(
+                    self.firewall, direction, ip_perm_entry)
+            else:
+                raise ec2e
+
+
 class AWSVMFirewallRule(BaseVMFirewallRule):
 
-    def __init__(self, provider, rule, parent):
-        super(AWSVMFirewallRule, self).__init__(provider, rule, parent)
+    def __init__(self, parent_fw, direction, rule):
+        self._direction = direction
+        super(AWSVMFirewallRule, self).__init__(parent_fw, rule)
+
+        # cache id
+        md5 = hashlib.md5()
+        md5.update(self._name.encode('ascii'))
+        self._id = md5.hexdigest()
 
     @property
     def id(self):
-        md5 = hashlib.md5()
-        md5.update("{0}-{1}-{2}-{3}".format(
-            self.ip_protocol, self.from_port, self.to_port, self.cidr_ip)
-            .encode('ascii'))
-        return md5.hexdigest()
+        return self._id
 
     @property
-    def ip_protocol(self):
+    def direction(self):
+        return self._direction
+
+    @property
+    def protocol(self):
         return self._rule.get('IpProtocol')
 
     @property
     def from_port(self):
-        return self._rule.get('FromPort', 0)
+        return self._rule.get('FromPort')
 
     @property
     def to_port(self):
-        return self._rule.get('ToPort', 0)
+        return self._rule.get('ToPort')
 
     @property
-    def cidr_ip(self):
-        if len(self._rule.get('IpRanges', [])) > 0:
+    def cidr(self):
+        if len(self._rule.get('IpRanges') or []) > 0:
             return self._rule['IpRanges'][0].get('CidrIp')
         return None
 
     @property
-    def group_id(self):
-        if len(self._rule['UserIdGroupPairs']) > 0:
+    def src_dest_fw_id(self):
+        if len(self._rule.get('UserIdGroupPairs') or []) > 0:
             return self._rule['UserIdGroupPairs'][0]['GroupId']
         else:
             return None
 
     @property
-    def group(self):
-        if self.group_id:
+    def src_dest_fw(self):
+        if self.src_dest_fw_id:
             return AWSVMFirewall(
                 self._provider,
-                self._provider.ec2_conn.SecurityGroup(self.group_id))
+                self._provider.ec2_conn.SecurityGroup(self.src_dest_fw_id))
         else:
             return None
 
-    def to_json(self):
-        attr = inspect.getmembers(self, lambda a: not (inspect.isroutine(a)))
-        js = {k: v for (k, v) in attr if not k.startswith('_')}
-        js['group'] = self.group.id if self.group else ''
-        js['parent'] = self.parent.id if self.parent else ''
-        return js
+    @staticmethod
+    def _construct_ip_perms(protocol, from_port, to_port, cidr,
+                            src_dest_fw_id):
+        return {
+            'IpProtocol': protocol,
+            'FromPort': from_port,
+            'ToPort': to_port,
+            'IpRanges': [{'CidrIp': cidr}] if cidr else None,
+            'UserIdGroupPairs': [{
+                'GroupId': src_dest_fw_id}
+            ] if src_dest_fw_id else None
+        }
 
     def delete(self):
-
-        ip_perm_entry = {
-            'IpProtocol': self.ip_protocol,
-            'FromPort': self.from_port,
-            'ToPort': self.to_port,
-            'IpRanges': [{'CidrIp': self.cidr_ip}] if self.cidr_ip else None,
-            'UserIdGroupPairs': [{
-                'GroupId': self.group_id}
-            ] if self.group_id else None
-        }
+        ip_perm_entry = self._construct_ip_perms(
+            self.protocol, self.from_port, self.to_port,
+            self.cidr, self.src_dest_fw_id)
 
         # Filter out empty values to please Boto
         ip_perms = [trim_empty_params(ip_perm_entry)]
 
-        self.parent._vm_firewall.revoke_ingress(IpPermissions=ip_perms)
-        self.parent._vm_firewall.reload()
+        # pylint:disable=protected-access
+        if self.direction == TrafficDirection.INBOUND:
+            self.firewall._vm_firewall.revoke_ingress(
+                IpPermissions=ip_perms)
+        else:
+            self.firewall._vm_firewall.revoke_egress(
+                IpPermissions=ip_perms)
+        self.firewall.refresh()
 
 
 class AWSBucketObject(BaseBucketObject):

--- a/cloudbridge/cloud/providers/openstack/resources.py
+++ b/cloudbridge/cloud/providers/openstack/resources.py
@@ -355,18 +355,17 @@ class OpenStackInstance(BaseInstance):
 
     @property
     def vm_firewalls(self):
-        """
-        Get the VM firewalls associated with this instance.
-        """
-        return [OpenStackVMFirewall(self._provider, group)
-                for group in self._os_instance.list_security_group()]
+        return [
+            self._provider.security.vm_firewalls.get(group.id)
+            for group in self._os_instance.list_security_group()
+        ]
 
     @property
     def vm_firewall_ids(self):
         """
         Get the VM firewall IDs associated with this instance.
         """
-        return [group.id for group in self.vm_firewalls]
+        return [fw.id for fw in self.vm_firewalls]
 
     @property
     def key_pair_name(self):

--- a/cloudbridge/cloud/providers/openstack/services.py
+++ b/cloudbridge/cloud/providers/openstack/services.py
@@ -20,18 +20,18 @@ from cloudbridge.cloud.base.services import BaseNetworkingService
 from cloudbridge.cloud.base.services import BaseObjectStoreService
 from cloudbridge.cloud.base.services import BaseRegionService
 from cloudbridge.cloud.base.services import BaseRouterService
-from cloudbridge.cloud.base.services import BaseSecurityGroupService
 from cloudbridge.cloud.base.services import BaseSecurityService
 from cloudbridge.cloud.base.services import BaseSnapshotService
 from cloudbridge.cloud.base.services import BaseSubnetService
+from cloudbridge.cloud.base.services import BaseVMFirewallService
 from cloudbridge.cloud.base.services import BaseVMTypeService
 from cloudbridge.cloud.base.services import BaseVolumeService
 from cloudbridge.cloud.interfaces.resources import KeyPair
 from cloudbridge.cloud.interfaces.resources import MachineImage
 from cloudbridge.cloud.interfaces.resources import PlacementZone
-from cloudbridge.cloud.interfaces.resources import SecurityGroup
 from cloudbridge.cloud.interfaces.resources import Snapshot
 from cloudbridge.cloud.interfaces.resources import Subnet
+from cloudbridge.cloud.interfaces.resources import VMFirewall
 from cloudbridge.cloud.interfaces.resources import VMType
 from cloudbridge.cloud.interfaces.resources import Volume
 from cloudbridge.cloud.providers.openstack import helpers as oshelpers
@@ -49,9 +49,9 @@ from .resources import OpenStackMachineImage
 from .resources import OpenStackNetwork
 from .resources import OpenStackRegion
 from .resources import OpenStackRouter
-from .resources import OpenStackSecurityGroup
 from .resources import OpenStackSnapshot
 from .resources import OpenStackSubnet
+from .resources import OpenStackVMFirewall
 from .resources import OpenStackVMType
 from .resources import OpenStackVolume
 
@@ -65,7 +65,7 @@ class OpenStackSecurityService(BaseSecurityService):
 
         # Initialize provider services
         self._key_pairs = OpenStackKeyPairService(provider)
-        self._security_groups = OpenStackSecurityGroupService(provider)
+        self._vm_firewalls = OpenStackVMFirewallService(provider)
 
     @property
     def key_pairs(self):
@@ -78,14 +78,14 @@ class OpenStackSecurityService(BaseSecurityService):
         return self._key_pairs
 
     @property
-    def security_groups(self):
+    def vm_firewalls(self):
         """
-        Provides access to security groups for this provider.
+        Provides access to VM firewalls for this provider.
 
-        :rtype: ``object`` of :class:`.SecurityGroupService`
-        :return: a SecurityGroupService object
+        :rtype: ``object`` of :class:`.VMFirewallService`
+        :return: a VMFirewallService object
         """
-        return self._security_groups
+        return self._vm_firewalls
 
     def get_or_create_ec2_credentials(self):
         """
@@ -175,85 +175,86 @@ class OpenStackKeyPairService(BaseKeyPairService):
         return None
 
 
-class OpenStackSecurityGroupService(BaseSecurityGroupService):
+class OpenStackVMFirewallService(BaseVMFirewallService):
 
     def __init__(self, provider):
-        super(OpenStackSecurityGroupService, self).__init__(provider)
+        super(OpenStackVMFirewallService, self).__init__(provider)
 
-    def get(self, sg_id):
+    def get(self, firewall_id):
         """
-        Returns a SecurityGroup given its id.
+        Returns a VMFirewall given its id.
         """
         try:
-            return OpenStackSecurityGroup(
-                self.provider, self.provider.nova.security_groups.get(sg_id))
+            return OpenStackVMFirewall(
+                self.provider,
+                self.provider.nova.security_groups.get(firewall_id))
         except NovaNotFound:
             return None
 
     def list(self, limit=None, marker=None):
         """
-        List all security groups associated with this account.
+        List all VM firewalls associated with this account.
 
-        :rtype: ``list`` of :class:`.SecurityGroup`
-        :return:  list of SecurityGroup objects
+        :rtype: ``list`` of :class:`.VMFirewall`
+        :return:  list of VMFirewall objects
         """
 
-        sgs = [OpenStackSecurityGroup(self.provider, sg)
-               for sg in self.provider.nova.security_groups.list()]
+        firewalls = [OpenStackVMFirewall(self.provider, fw)
+                     for fw in self.provider.nova.security_groups.list()]
 
-        return ClientPagedResultList(self.provider, sgs,
+        return ClientPagedResultList(self.provider, firewalls,
                                      limit=limit, marker=marker)
 
     def create(self, name, description, network_id):
         """
-        Create a new security group under the current account.
+        Create a new VM firewall under the current account.
 
         :type name: str
-        :param name: The name of the new security group.
+        :param name: The name of the new VM firewall.
 
         :type description: str
-        :param description: The description of the new security group.
+        :param description: The description of the new VM firewall.
 
         :type  network_id: ``None``
         :param network_id: Not applicable for OpenStack (yet) so any value is
                            ignored.
 
-        :rtype: ``object`` of :class:`.SecurityGroup`
-        :return: a SecurityGroup object
+        :rtype: ``object`` of :class:`.VMFirewall`
+        :return: a VMFirewall object
         """
-        OpenStackSecurityGroup.assert_valid_resource_name(name)
+        OpenStackVMFirewall.assert_valid_resource_name(name)
 
         sg = self.provider.nova.security_groups.create(name, description)
         if sg:
-            return OpenStackSecurityGroup(self.provider, sg)
+            return OpenStackVMFirewall(self.provider, sg)
         return None
 
     def find(self, name, limit=None, marker=None):
         """
-        Get all security groups associated with your account.
+        Get all VM firewalls associated with your account.
         """
         sgs = self.provider.nova.security_groups.findall(name=name)
-        results = [OpenStackSecurityGroup(self.provider, sg)
+        results = [OpenStackVMFirewall(self.provider, sg)
                    for sg in sgs]
         return ClientPagedResultList(self.provider, results,
                                      limit=limit, marker=marker)
 
     def delete(self, group_id):
         """
-        Delete an existing SecurityGroup.
+        Delete an existing VMFirewall.
 
         :type group_id: str
-        :param group_id: The security group ID to be deleted.
+        :param group_id: The VM firewall ID to be deleted.
 
         :rtype: ``bool``
-        :return:  ``True`` if the security group does not exist, ``False``
+        :return:  ``True`` if the VM firewall does not exist, ``False``
                   otherwise. Note that this implies that the group may not have
                   been deleted by this method but instead has not existed in
                   the first place.
         """
-        sg = self.get(group_id)
-        if sg:
-            sg.delete()
+        firewall = self.get(group_id)
+        if firewall:
+            firewall.delete()
         return True
 
 
@@ -567,7 +568,7 @@ class OpenStackInstanceService(BaseInstanceService):
         super(OpenStackInstanceService, self).__init__(provider)
 
     def create(self, name, image, vm_type, subnet, zone=None,
-               key_pair=None, security_groups=None, user_data=None,
+               key_pair=None, vm_firewalls=None, user_data=None,
                launch_config=None,
                **kwargs):
         """Create a new virtual machine instance."""
@@ -604,13 +605,13 @@ class OpenStackInstanceService(BaseInstanceService):
             log.debug("Creating network port for %s in subnet: %s" %
                       (name, subnet_id))
             sg_list = []
-            if security_groups:
-                if isinstance(security_groups, list) and \
-                        isinstance(security_groups[0], SecurityGroup):
-                    sg_list = security_groups
+            if vm_firewalls:
+                if isinstance(vm_firewalls, list) and \
+                        isinstance(vm_firewalls[0], VMFirewall):
+                    sg_list = vm_firewalls
                 else:
-                    sg_list = (self.provider.security.security_groups
-                               .find(name=sg) for sg in security_groups)
+                    sg_list = (self.provider.security.vm_firewalls
+                               .find(name=sg) for sg in vm_firewalls)
                     sg_list = (sg[0] for sg in sg_list if sg)
             sg_id_list = [sg.id for sg in sg_list]
             port_def = {
@@ -625,12 +626,12 @@ class OpenStackInstanceService(BaseInstanceService):
             port_id = self.provider.neutron.create_port(port_def)['port']['id']
             nics = [{'net-id': net_id, 'port-id': port_id}]
         else:
-            if security_groups:
-                if isinstance(security_groups, list) and \
-                        isinstance(security_groups[0], SecurityGroup):
-                    sg_name_list = [sg.name for sg in security_groups]
+            if vm_firewalls:
+                if isinstance(vm_firewalls, list) and \
+                        isinstance(vm_firewalls[0], VMFirewall):
+                    sg_name_list = [sg.name for sg in vm_firewalls]
                 else:
-                    sg_name_list = security_groups
+                    sg_name_list = vm_firewalls
 
         log.debug("Launching in subnet %s" % subnet_id)
         os_instance = self.provider.nova.servers.create(

--- a/cloudbridge/cloud/providers/openstack/services.py
+++ b/cloudbridge/cloud/providers/openstack/services.py
@@ -181,9 +181,6 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
         super(OpenStackVMFirewallService, self).__init__(provider)
 
     def get(self, firewall_id):
-        """
-        Returns a VMFirewall given its id.
-        """
         try:
             return OpenStackVMFirewall(
                 self.provider,
@@ -192,13 +189,6 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
             return None
 
     def list(self, limit=None, marker=None):
-        """
-        List all VM firewalls associated with this account.
-
-        :rtype: ``list`` of :class:`.VMFirewall`
-        :return:  list of VMFirewall objects
-        """
-
         firewalls = [OpenStackVMFirewall(self.provider, fw)
                      for fw in self.provider.nova.security_groups.list()]
 
@@ -206,22 +196,6 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
                                      limit=limit, marker=marker)
 
     def create(self, name, description, network_id):
-        """
-        Create a new VM firewall under the current account.
-
-        :type name: str
-        :param name: The name of the new VM firewall.
-
-        :type description: str
-        :param description: The description of the new VM firewall.
-
-        :type  network_id: ``None``
-        :param network_id: Not applicable for OpenStack (yet) so any value is
-                           ignored.
-
-        :rtype: ``object`` of :class:`.VMFirewall`
-        :return: a VMFirewall object
-        """
         OpenStackVMFirewall.assert_valid_resource_name(name)
 
         sg = self.provider.nova.security_groups.create(name, description)
@@ -230,9 +204,6 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
         return None
 
     def find(self, name, limit=None, marker=None):
-        """
-        Get all VM firewalls associated with your account.
-        """
         sgs = self.provider.nova.security_groups.findall(name=name)
         results = [OpenStackVMFirewall(self.provider, sg)
                    for sg in sgs]
@@ -240,18 +211,6 @@ class OpenStackVMFirewallService(BaseVMFirewallService):
                                      limit=limit, marker=marker)
 
     def delete(self, group_id):
-        """
-        Delete an existing VMFirewall.
-
-        :type group_id: str
-        :param group_id: The VM firewall ID to be deleted.
-
-        :rtype: ``bool``
-        :return:  ``True`` if the VM firewall does not exist, ``False``
-                  otherwise. Note that this implies that the group may not have
-                  been deleted by this method but instead has not existed in
-                  the first place.
-        """
         firewall = self.get(group_id)
         if firewall:
             firewall.delete()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQS_BASE = [
 ]
 REQS_AWS = ['boto3']
 REQS_OPENSTACK = [
+    'openstacksdk',
     'python-novaclient==7.0.0',
     'python-glanceclient>=2.5.0,<=2.6.0',
     'python-cinderclient>=1.9.0,<=2.0.1',

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -122,7 +122,7 @@ def delete_test_network(network):
 
 def create_test_instance(
         provider, instance_name, subnet, launch_config=None,
-        key_pair=None, security_groups=None):
+        key_pair=None, vm_firewalls=None):
     return provider.compute.instances.create(
         instance_name,
         get_provider_test_data(provider, 'image'),
@@ -130,11 +130,11 @@ def create_test_instance(
         subnet=subnet,
         zone=get_provider_test_data(provider, 'placement'),
         key_pair=key_pair,
-        security_groups=security_groups,
+        vm_firewalls=vm_firewalls,
         launch_config=launch_config)
 
 
-def get_test_instance(provider, name, key_pair=None, security_groups=None,
+def get_test_instance(provider, name, key_pair=None, vm_firewalls=None,
                       subnet=None):
     launch_config = None
     instance = create_test_instance(
@@ -142,7 +142,7 @@ def get_test_instance(provider, name, key_pair=None, security_groups=None,
         name,
         subnet=subnet,
         key_pair=key_pair,
-        security_groups=security_groups,
+        vm_firewalls=vm_firewalls,
         launch_config=launch_config)
     instance.wait_till_ready()
     return instance
@@ -159,14 +159,14 @@ def delete_test_instance(instance):
                           terminal_states=[InstanceState.ERROR])
 
 
-def cleanup_test_resources(instance=None, network=None, security_group=None,
+def cleanup_test_resources(instance=None, network=None, vm_firewall=None,
                            key_pair=None):
     """Clean up any combination of supplied resources."""
     with cleanup_action(lambda: delete_test_network(network)
                         if network else None):
         with cleanup_action(lambda: key_pair.delete() if key_pair else None):
-            with cleanup_action(lambda: security_group.delete()
-                                if security_group else None):
+            with cleanup_action(lambda: vm_firewall.delete()
+                                if vm_firewall else None):
                 delete_test_instance(instance)
 
 

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import sys
+import traceback
 import unittest
 import uuid
 
@@ -46,11 +47,13 @@ def cleanup_action(cleanup_func):
             cleanup_func()
         except Exception as e:
             print("Error during exception cleanup: {0}".format(e))
+            traceback.print_exc()
         reraise(ex_class, ex_val, ex_traceback)
     try:
         cleanup_func()
     except Exception as e:
         print("Error during cleanup: {0}".format(e))
+        traceback.print_exc()
 
 
 def skipIfNoService(services):

--- a/test/test_compute_service.py
+++ b/test/test_compute_service.py
@@ -112,12 +112,14 @@ class CloudComputeServiceTestCase(ProviderTestBase):
             ip_address = test_instance.public_ips[0] \
                 if test_instance.public_ips and test_instance.public_ips[0] \
                 else ip_private
+            # Convert to unicode for py27 compatibility with ipaddress()
+            ip_address = u"{}".format(ip_address)
             self.assertIsNotNone(
                 ip_address,
                 "Instance must have either a public IP or a private IP")
             self.assertTrue(
                 self._is_valid_ip(ip_address),
-                "Instance must have a valid IP address")
+                "Instance must have a valid IP address. Got: %s" % ip_address)
             self.assertIsInstance(test_instance.vm_type_id,
                                   six.string_types)
             vm_type = self.provider.compute.vm_types.get(

--- a/test/test_compute_service.py
+++ b/test/test_compute_service.py
@@ -59,7 +59,7 @@ class CloudComputeServiceTestCase(ProviderTestBase):
         return True
 
     @helpers.skipIfNoService(['compute.instances', 'networking.networks',
-                              'security.security_groups',
+                              'security.vm_firewalls',
                               'security.key_pairs'])
     def test_instance_properties(self):
         name = "cb_inst_props-{0}".format(helpers.get_uuid())
@@ -68,17 +68,17 @@ class CloudComputeServiceTestCase(ProviderTestBase):
         # the cleanup method access to the most current values
         test_instance = None
         net = None
-        sg = None
+        fw = None
         kp = None
         with helpers.cleanup_action(lambda: helpers.cleanup_test_resources(
-                test_instance, net, sg, kp)):
+                test_instance, net, fw, kp)):
             net, subnet = helpers.create_test_network(self.provider, name)
             kp = self.provider.security.key_pairs.create(name=name)
-            sg = self.provider.security.security_groups.create(
+            fw = self.provider.security.vm_firewalls.create(
                 name=name, description=name, network_id=net.id)
             test_instance = helpers.get_test_instance(self.provider,
                                                       name, key_pair=kp,
-                                                      security_groups=[sg],
+                                                      vm_firewalls=[fw],
                                                       subnet=subnet)
             self.assertEqual(
                 test_instance.name, name,
@@ -98,14 +98,14 @@ class CloudComputeServiceTestCase(ProviderTestBase):
             self.assertEqual(
                 test_instance.key_pair_name,
                 kp.name)
-            self.assertIsInstance(test_instance.security_groups, list)
+            self.assertIsInstance(test_instance.vm_firewalls, list)
             self.assertEqual(
-                test_instance.security_groups[0],
-                sg)
-            self.assertIsInstance(test_instance.security_group_ids, list)
+                test_instance.vm_firewalls[0],
+                fw)
+            self.assertIsInstance(test_instance.vm_firewall_ids, list)
             self.assertEqual(
-                test_instance.security_group_ids[0],
-                sg.id)
+                test_instance.vm_firewall_ids[0],
+                fw.id)
             # Must have either a public or a private ip
             ip_private = test_instance.private_ips[0] \
                 if test_instance.private_ips else None
@@ -287,7 +287,7 @@ class CloudComputeServiceTestCase(ProviderTestBase):
                         # correspond to requested mappings
 
     @helpers.skipIfNoService(['compute.instances', 'networking.networks',
-                              'security.security_groups'])
+                              'security.vm_firewalls'])
     def test_instance_methods(self):
         name = "cb_instmethods-{0}".format(helpers.get_uuid())
 
@@ -295,30 +295,30 @@ class CloudComputeServiceTestCase(ProviderTestBase):
         # the cleanup method access to the most current values
         test_inst = None
         net = None
-        sg = None
+        fw = None
         with helpers.cleanup_action(lambda: helpers.cleanup_test_resources(
-                test_inst, net, sg)):
+                test_inst, net, fw)):
             net, subnet = helpers.create_test_network(self.provider, name)
             test_inst = helpers.get_test_instance(self.provider, name,
                                                   subnet=subnet)
-            sg = self.provider.security.security_groups.create(
+            fw = self.provider.security.vm_firewalls.create(
                 name=name, description=name, network_id=net.id)
 
-            # Check adding a security group to a running instance
-            test_inst.add_security_group(sg)
+            # Check adding a VM firewall to a running instance
+            test_inst.add_vm_firewall(fw)
             test_inst.refresh()
             self.assertTrue(
-                sg in test_inst.security_groups, "Expected security group '%s'"
-                " to be among instance security_groups: [%s]" %
-                (sg, test_inst.security_groups))
+                fw in test_inst.vm_firewalls, "Expected VM firewall '%s'"
+                " to be among instance vm_firewalls: [%s]" %
+                (fw, test_inst.vm_firewalls))
 
-            # Check removing a security group from a running instance
-            test_inst.remove_security_group(sg)
+            # Check removing a VM firewall from a running instance
+            test_inst.remove_vm_firewall(fw)
             test_inst.refresh()
             self.assertTrue(
-                sg not in test_inst.security_groups, "Expected security group"
-                " '%s' to be removed from instance security_groups: [%s]" %
-                (sg, test_inst.security_groups))
+                fw not in test_inst.vm_firewalls, "Expected VM firewall"
+                " '%s' to be removed from instance vm_firewalls: [%s]" %
+                (fw, test_inst.vm_firewalls))
 
             # check floating ips
             router = self.provider.networking.routers.create(name, net)


### PR DESCRIPTION
This PR does the following:
1. Renames security groups->VM firewall
2. Increased the uniformity of SecurityGroupRules by making them service like i.e. have CRUD methods and iteration. However, they have not been turned into a cloudbridge "Service" because it creates circular dependencies, since the firewall must have a reference to the rules. Instead, the VMFirewallRuleContainer remains in resources.py
3. Nova security groups do not support traffic direction. They have also bee deprecated, preventing a nova upgrade. Therefore, they've been replaced by neutron security groups, with a partial migration to the Openstack SDK.
