### PR TITLE
Add support for GCE resource get method to use either id (resource URL) or short name

### DIFF
--- a/cloudbridge/cloud/providers/gce/provider.py
+++ b/cloudbridge/cloud/providers/gce/provider.py
@@ -168,7 +168,7 @@ class GCPResources(object):
         short name, then we build the GCPResourceUrl object by constructing
         the resource URL with default project, region, zone values.
         """
-        # If identifier is a valid GCP resource URL, the parse it.
+        # If identifier is a valid GCP resource URL, then parse it.
         if identifier.startswith(self._root_url):
             return self.parse_url(identifier)
         # Otherwise, construct resource URL with default values.

--- a/cloudbridge/cloud/providers/gce/provider.py
+++ b/cloudbridge/cloud/providers/gce/provider.py
@@ -312,8 +312,8 @@ class GCECloudProvider(BaseCloudProvider):
             return None
         try:
             res = resource_url.get_resource()
+            return res
         except googleapiclient.errors.HttpError as http_error:
             cb.log.warning(
                 "googleapiclient.errors.HttpError: {0}".format(http_error))
             return None
-        return res

--- a/cloudbridge/cloud/providers/gce/provider.py
+++ b/cloudbridge/cloud/providers/gce/provider.py
@@ -311,8 +311,7 @@ class GCECloudProvider(BaseCloudProvider):
         if resource_url is None:
             return None
         try:
-            res = resource_url.get_resource()
-            return res
+            return resource_url.get_resource()
         except googleapiclient.errors.HttpError as http_error:
             cb.log.warning(
                 "googleapiclient.errors.HttpError: {0}".format(http_error))

--- a/cloudbridge/cloud/providers/gce/resources.py
+++ b/cloudbridge/cloud/providers/gce/resources.py
@@ -152,7 +152,7 @@ class GCEPlacementZone(BasePlacementZone):
         :rtype: ``str``
         :return: ID for this zone as returned by the cloud middleware.
         """
-        return self._gce_zone
+        return self._gce_zone.get('selfLink')
 
     @property
     def name(self):
@@ -161,7 +161,7 @@ class GCEPlacementZone(BasePlacementZone):
         :rtype: ``str``
         :return: Name for this zone as returned by the cloud middleware.
         """
-        return self._gce_zone
+        return self._gce_zone.get('name')
 
     @property
     def region_name(self):
@@ -181,16 +181,11 @@ class GCERegion(BaseRegion):
 
     @property
     def id(self):
-        # In GCE API, region has an 'id' property, whose values are '1220',
-        # '1100', '1000', '1230', etc. Here we use 'name' property (such
-        # as 'asia-east1', 'europe-west1', 'us-central1', 'us-east1') as
-        # 'id' to represent the region for the consistency with AWS
-        # implementation and ease of use.
-        return self._gce_region['name']
+        return self._gce_region.get('selfLink')
 
     @property
     def name(self):
-        return self._gce_region['name']
+        return self._gce_region.get('name')
 
     @property
     def zones(self):
@@ -204,7 +199,7 @@ class GCERegion(BaseRegion):
                               .execute())
         zones = [zone for zone in zones_response['items']
                  if zone['region'] == self._gce_region['selfLink']]
-        return [GCEPlacementZone(self._provider, zone['name'], self.name)
+        return [GCEPlacementZone(self._provider, zone, self.name)
                 for zone in zones]
 
 
@@ -825,11 +820,7 @@ class GCEInstance(BaseInstance):
         """
         Get the instance type name.
         """
-        machine_type_uri = self._gce_instance.get('machineType')
-        if machine_type_uri is None:
-            return None
-        parsed_uri = self._provider.parse_url(machine_type_uri)
-        return parsed_uri.parameters['machineType']
+        return self._gce_instance.get('machineType')
 
     @property
     def instance_type(self):
@@ -905,10 +896,7 @@ class GCEInstance(BaseInstance):
         """
         Get the placement zone id where this instance is running.
         """
-        zone_uri = self._gce_instance.get('zone')
-        if zone_uri is None:
-            return None
-        return self._provider.parse_url(zone_uri).parameters['zone']
+        return self._gce_instance.get('zone')
 
     @property
     def security_groups(self):
@@ -1203,7 +1191,7 @@ class GCENetwork(BaseNetwork):
 
     @property
     def id(self):
-        return self._network['id']
+        return self._network['selfLink']
 
     @property
     def name(self):
@@ -1293,7 +1281,7 @@ class GCEFloatingIP(BaseFloatingIP):
 
     @property
     def id(self):
-        return self._ip['id']
+        return self._ip['selfLink']
 
     @property
     def region(self):
@@ -1345,7 +1333,7 @@ class GCERouter(BaseRouter):
 
     @property
     def id(self):
-        return self._router['id']
+        return self._router['selfLink']
 
     @property
     def name(self):
@@ -1364,7 +1352,7 @@ class GCERouter(BaseRouter):
     def network_id(self):
         parsed_url = self._provider.parse_url(self._router['network'])
         network = parsed_url.get_resource()
-        return network['id']
+        return network['selfLink']
 
     def delete(self):
         response = (self._provider
@@ -1400,7 +1388,7 @@ class GCESubnet(BaseSubnet):
 
     @property
     def id(self):
-        return self._subnet['id']
+        return self._subnet['selfLink']
 
     @property
     def name(self):
@@ -1422,7 +1410,8 @@ class GCESubnet(BaseSubnet):
 
     @property
     def network_id(self):
-        return self._provider.parse_url(self.network_url).get_resource()['id']
+        return self._provider.parse_url(
+            self.network_url).get_resource()['selfLink']
 
     @property
     def region(self):
@@ -1743,7 +1732,7 @@ class GCSObject(BaseBucketObject):
 
     @property
     def id(self):
-        return self._obj['id']
+        return self._obj['selfLink']
 
     @property
     def name(self):
@@ -1807,7 +1796,7 @@ class GCSBucket(BaseBucket):
 
     @property
     def id(self):
-        return self._bucket['id']
+        return self._bucket['selfLink']
 
     @property
     def name(self):

--- a/cloudbridge/cloud/providers/gce/services.py
+++ b/cloudbridge/cloud/providers/gce/services.py
@@ -290,9 +290,7 @@ class GCEInstanceTypesService(BaseInstanceTypesService):
 
     def get(self, instance_type_id):
         inst_type = self.provider.get_resource('machineTypes', instance_type_id)
-        if inst_type:
-            return GCEInstanceType(self.provider, inst_type)
-        return None
+        return GCEInstanceType(self.provider, inst_type) if inst_type else None
 
     def find(self, **kwargs):
         matched_inst_types = []
@@ -323,9 +321,7 @@ class GCERegionService(BaseRegionService):
 
     def get(self, region_id):
         region = self.provider.get_resource('regions', region_id)
-        if region:
-            return GCERegion(self.provider, region)
-        return None
+        return GCERegion(self.provider, region) if region else None
 
     def list(self, limit=None, marker=None):
         max_result = limit if limit is not None and limit < 500 else 500
@@ -378,9 +374,7 @@ class GCEImageService(BaseImageService):
         Returns an Image given its id
         """
         image = self.provider.get_resource('images', image_id)
-        if image:
-            return GCEMachineImage(self.provider, image)
-        return None
+        return GCEMachineImage(self.provider, image) if image else None
 
     def find(self, name, limit=None, marker=None):
         """
@@ -489,9 +483,7 @@ class GCEInstanceService(BaseInstanceService):
         as its id.
         """
         instance = self.provider.get_resource('instances', instance_id)
-        if instance:
-            return GCEInstance(self.provider, instance)
-        return None
+        return GCEInstance(self.provider, instance) if instance else None
 
     def find(self, name, limit=None, marker=None):
         """
@@ -565,9 +557,7 @@ class GCENetworkService(BaseNetworkService):
 
     def get(self, network_id):
         network = self.provider.get_resource('networks', network_id)
-        if network:
-            return GCENetwork(self.provider, network)
-        return None
+        return GCENetwork(self.provider, network) if network else None
 
     def get_by_name(self, network_name):
         if network_name is None:
@@ -717,9 +707,7 @@ class GCESubnetService(BaseSubnetService):
 
     def get(self, subnet_id):
         subnet = self.provider.get_resource('subnetworks', subnet_id)
-        if subnet:
-            return GCESubnet(self.provider, subnet)
-        return None
+        return GCESubnet(self.provider, subnet) if subnet else None
 
     def list(self, network=None, zone=None, limit=None, marker=None):
         region = zone.region_name if zone else self.provider.region_name
@@ -835,9 +823,7 @@ class GCEVolumeService(BaseVolumeService):
         Returns a volume given its id.
         """
         vol = self.provider.get_resource('disks', volume_id)
-        if vol:
-            return GCEVolume(self.provider, vol)
-        return None
+        return GCEVolume(self.provider, vol) if vol else None
 
     def find(self, name, limit=None, marker=None):
         """
@@ -937,9 +923,7 @@ class GCESnapshotService(BaseSnapshotService):
         Returns a snapshot given its id.
         """
         snapshot = self.provider.get_resource('snapshots', snapshot_id)
-        if snapshot:
-            return GCESnapshot(self.provider, snapshot)
-        return None
+        return GCESnapshot(self.provider, snapshot) if snapshot else None
 
     def find(self, name, limit=None, marker=None):
         """
@@ -1030,9 +1014,7 @@ class GCSObjectStoreService(BaseObjectStoreService):
         bucket.
         """
         bucket = self.provider.get_resource('buckets', bucket_id)
-        if bucket:
-            return GCSBucket(self.provider, bucket)
-        return None
+        return GCSBucket(self.provider, bucket) if bucket else None
 
     def find(self, name, limit=None, marker=None):
         """


### PR DESCRIPTION
Hi @nuwang @afgane @chiniforooshan @mbookman,

This pull request includes following changes:
(1) add support for GCE resource get method to use either id (resource URL) or short name;
(2) make it consistent to use resource URL as GCE resource ID (wherever applicable).

Thanks!
